### PR TITLE
Use Clang TypeSystem for OCaml debugging

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -109,7 +109,9 @@ TypeSystemClangSupportsLanguage(lldb::LanguageType language) {
          // Use Clang for D until there is a proper language plugin for it
          language == eLanguageTypeD ||
          // Open Dylan compiler debug info is designed to be Clang-compatible
-         language == eLanguageTypeDylan;
+         language == eLanguageTypeDylan ||
+         // For the moment use the Clang code for OCaml
+         language == eLanguageTypeOCaml;
 }
 
 // Checks whether m1 is an overload of m2 (as opposed to an override). This is


### PR DESCRIPTION
For the moment we can use the C/C++ code for dealing with OCaml debugging.  In due course it looks like we should add `Plugins/TypeSystem/OCaml`.