### PR TITLE
Hack to print OCaml values as pointers or integers

### DIFF
--- a/clang/include/clang/AST/ASTContext.h
+++ b/clang/include/clang/AST/ASTContext.h
@@ -1107,6 +1107,7 @@ public:
   CanQualType PseudoObjectTy, ARCUnbridgedCastTy;
   CanQualType ObjCBuiltinIdTy, ObjCBuiltinClassTy, ObjCBuiltinSelTy;
   CanQualType ObjCBuiltinBoolTy;
+  CanQualType OCamlValueTy;
 #define IMAGE_TYPE(ImgType, Id, SingletonId, Access, Suffix) \
   CanQualType SingletonId;
 #include "clang/Basic/OpenCLImageTypes.def"

--- a/clang/include/clang/AST/BuiltinTypes.def
+++ b/clang/include/clang/AST/BuiltinTypes.def
@@ -226,6 +226,9 @@ FLOATING_TYPE(Ibm128, Ibm128Ty)
 // This is the type of C++0x 'nullptr'.
 BUILTIN_TYPE(NullPtr, NullPtrTy)
 
+// OCaml values
+BUILTIN_TYPE(OCamlValue, OCamlValueTy)
+
 // The primitive Objective C 'id' type.  The user-visible 'id'
 // type is a typedef of an ObjCObjectPointerType to an
 // ObjCObjectType with this as its base.  In fact, this only ever

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -1441,6 +1441,8 @@ void ASTContext::InitBuiltinTypes(const TargetInfo &Target,
 
   ObjCSuperType = QualType();
 
+  InitBuiltinType(OCamlValueTy, BuiltinType::OCamlValue);
+
   // void * type
   if (LangOpts.OpenCLGenericAddressSpace) {
     auto Q = VoidTy.getQualifiers();
@@ -2040,6 +2042,10 @@ TypeInfo ASTContext::getTypeInfoImpl(const Type *T) const {
   case Type::Builtin:
     switch (cast<BuiltinType>(T)->getKind()) {
     default: llvm_unreachable("Unknown builtin type!");
+    case BuiltinType::OCamlValue:
+      Width = 64;
+      Align = 64;
+      break;
     case BuiltinType::Void:
       // GCC extension: alignof(void) = 8 bits.
       Width = 0;
@@ -8037,6 +8043,9 @@ static char getObjCEncodingForPrimitiveType(const ASTContext *C,
         Diags.Report(DiagID) << BT->getName(C->getPrintingPolicy());
         return ' ';
       }
+
+    case BuiltinType::OCamlValue:
+      llvm_unreachable("@encoding OCaml value type");
 
     case BuiltinType::ObjCId:
     case BuiltinType::ObjCClass:

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -11338,6 +11338,7 @@ EvaluateBuiltinClassifyType(QualType T, const LangOptions &LangOpts) {
 
     case BuiltinType::NullPtr:
 
+    case BuiltinType::OCamlValue:
     case BuiltinType::ObjCId:
     case BuiltinType::ObjCClass:
     case BuiltinType::ObjCSel:

--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -3064,6 +3064,9 @@ void CXXNameMangler::mangleType(const BuiltinType *T) {
     Out << "Dn";
     break;
 
+  case BuiltinType::OCamlValue:
+    llvm_unreachable("mangling an OCaml value type");
+
 #define BUILTIN_TYPE(Id, SingletonId)
 #define PLACEHOLDER_TYPE(Id, SingletonId) \
   case BuiltinType::Id:

--- a/clang/lib/AST/MicrosoftMangle.cpp
+++ b/clang/lib/AST/MicrosoftMangle.cpp
@@ -2415,6 +2415,9 @@ void MicrosoftCXXNameMangler::mangleType(const BuiltinType *T, Qualifiers,
   case BuiltinType::Dependent:
     llvm_unreachable("placeholder types shouldn't get to name mangling");
 
+  case BuiltinType::OCamlValue:
+    llvm_unreachable("cannot mangle OCaml value types");
+
   case BuiltinType::ObjCId:
     mangleArtificialTagType(TTK_Struct, "objc_object");
     break;

--- a/clang/lib/AST/NSAPI.cpp
+++ b/clang/lib/AST/NSAPI.cpp
@@ -459,6 +459,7 @@ NSAPI::getNSNumberFactoryMethodKind(QualType T) const {
   case BuiltinType::Float128:
   case BuiltinType::Ibm128:
   case BuiltinType::NullPtr:
+  case BuiltinType::OCamlValue:
   case BuiltinType::ObjCClass:
   case BuiltinType::ObjCId:
   case BuiltinType::ObjCSel:

--- a/clang/lib/AST/Type.cpp
+++ b/clang/lib/AST/Type.cpp
@@ -3106,6 +3106,8 @@ StringRef BuiltinType::getName(const PrintingPolicy &Policy) const {
     return "<ARC unbridged cast type>";
   case BuiltinFn:
     return "<builtin fn type>";
+  case OCamlValue:
+    return "ocaml_value";
   case ObjCId:
     return "id";
   case ObjCClass:
@@ -4257,6 +4259,7 @@ bool Type::canHaveNullability(bool ResultIfUnknown) const {
       return ResultIfUnknown;
 
     case BuiltinType::Void:
+    case BuiltinType::OCamlValue:
     case BuiltinType::ObjCId:
     case BuiltinType::ObjCClass:
     case BuiltinType::ObjCSel:

--- a/clang/lib/AST/TypeLoc.cpp
+++ b/clang/lib/AST/TypeLoc.cpp
@@ -402,6 +402,7 @@ TypeSpecifierType BuiltinTypeLoc::getWrittenTypeSpec() const {
   case BuiltinType::UnknownAny:
   case BuiltinType::ARCUnbridgedCast:
   case BuiltinType::PseudoObject:
+  case BuiltinType::OCamlValue:
   case BuiltinType::ObjCId:
   case BuiltinType::ObjCClass:
   case BuiltinType::ObjCSel:

--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -844,6 +844,7 @@ llvm::DIType *CGDebugInfo::CreateType(const BuiltinType *BT) {
   case BuiltinType::Long:
   case BuiltinType::WChar_S:
   case BuiltinType::LongLong:
+  case BuiltinType::OCamlValue:
     Encoding = llvm::dwarf::DW_ATE_signed;
     break;
   case BuiltinType::Bool:

--- a/clang/lib/CodeGen/CodeGenTypes.cpp
+++ b/clang/lib/CodeGen/CodeGenTypes.cpp
@@ -512,6 +512,7 @@ llvm::Type *CodeGenTypes::ConvertType(QualType T) {
     case BuiltinType::SatUShortFract:
     case BuiltinType::SatUFract:
     case BuiltinType::SatULongFract:
+    case BuiltinType::OCamlValue:
       ResultType = llvm::IntegerType::get(getLLVMContext(),
                                  static_cast<unsigned>(Context.getTypeSize(T)));
       break;

--- a/clang/lib/CodeGen/ItaniumCXXABI.cpp
+++ b/clang/lib/CodeGen/ItaniumCXXABI.cpp
@@ -3315,6 +3315,7 @@ static bool TypeInfoIsInStandardLibrary(const BuiltinType *Ty) {
     case BuiltinType::SatUFract:
     case BuiltinType::SatULongFract:
     case BuiltinType::BFloat16:
+    case BuiltinType::OCamlValue:
       return false;
 
     case BuiltinType::Dependent:

--- a/clang/lib/Serialization/ASTCommon.cpp
+++ b/clang/lib/Serialization/ASTCommon.cpp
@@ -268,6 +268,8 @@ serialization::TypeIdxFromBuiltin(const BuiltinType *BT) {
   case BuiltinType::BFloat16:
     ID = PREDEF_TYPE_BFLOAT16_ID;
     break;
+  case BuiltinType::OCamlValue:
+    llvm_unreachable("not implemented");
   }
 
   return TypeIdx(ID);

--- a/lldb/include/lldb/lldb-enumerations.h
+++ b/lldb/include/lldb/lldb-enumerations.h
@@ -200,6 +200,7 @@ enum Format {
   eFormatInstruction, ///< Disassemble an opcode
   eFormatVoid,        ///< Do not print this
   eFormatUnicode8,
+  eFormatOCamlValue,
   kNumFormats
 };
 
@@ -785,6 +786,7 @@ enum BasicType {
   eBasicTypeObjCClass,
   eBasicTypeObjCSel,
   eBasicTypeNullPtr,
+  eBasicTypeOCamlValue,
   eBasicTypeOther
 };
 

--- a/lldb/source/Commands/CommandObjectMemory.cpp
+++ b/lldb/source/Commands/CommandObjectMemory.cpp
@@ -1420,6 +1420,7 @@ protected:
       case eFormatVectorOfFloat32:
       case eFormatVectorOfFloat64:
       case eFormatVectorOfUInt128:
+      case eFormatOCamlValue:
       case eFormatOSType:
       case eFormatComplexInteger:
       case eFormatAddressInfo:

--- a/lldb/source/Core/DumpDataExtractor.cpp
+++ b/lldb/source/Core/DumpDataExtractor.cpp
@@ -338,6 +338,339 @@ static const llvm::fltSemantics &GetFloatSemantics(const TargetSP &target_sp,
   return llvm::APFloat::Bogus();
 }
 
+static offset_t FormatOCamlValue(const DataExtractor &DE, Stream *s,
+                                 offset_t start_offset, uint64_t base_addr,
+                                 ExecutionContextScope *exe_ctx_scope,
+                                 llvm::DenseSet<lldb::addr_t> pointers_seen,
+                                 int depth, bool is_lazy_closure = false) {
+  offset_t offset = start_offset;
+  uint64_t value = DE.GetU64(&offset);
+  if (offset == start_offset) {
+    s->Printf("<could not read value>");
+    return offset;
+  }
+
+  if ((value & 0x1) == 1) {
+    /* Tagged immediate */
+    s->Printf("%" PRId64, value >> 1);
+  } else if (pointers_seen.contains(value)) {
+    s->Printf("<cyclic value>@");
+  } else {
+    bool print_default = true;
+    ExecutionContext exe_ctx;
+
+    pointers_seen.insert(value);
+
+    if (exe_ctx_scope)
+      exe_ctx_scope->CalculateExecutionContext(exe_ctx);
+    Process *process = exe_ctx.GetProcessPtr();
+
+    if (process) {
+      Status error;
+      lldb::addr_t header = process->ReadPointerFromMemory(value - 8, error);
+
+      if (error.Fail()) {
+        s->Printf("<could not read header>@");
+      } else {
+        uint8_t tag = header & 0xff;
+        uint64_t wosize = header >> 10;
+
+        switch (tag) {
+        case 246: { // Lazy_tag
+          lldb::addr_t computation_ptr =
+              process->ReadPointerFromMemory(value, error);
+          if (error.Fail()) {
+            s->Printf("<lazy, could not read computation pointer>@");
+          } else {
+            offset_t offset = 0;
+            DataExtractor field_data(&computation_ptr, 8,
+                                     process->GetByteOrder(), 8);
+            s->Printf("<lazy|");
+            (void)FormatOCamlValue(field_data, s, offset, base_addr,
+                                   exe_ctx_scope, pointers_seen, depth, true);
+            s->Printf(">");
+            print_default = false;
+          }
+          break;
+        }
+
+        case 247:   // Closure_tag
+        case 249: { // Infix_tag
+          uint64_t closinfo =
+              process->ReadUnsignedIntegerFromMemory(value + 8, 8, 0, error);
+          if (error.Fail()) {
+            s->Printf("<could not read closinfo word from closure>@");
+          } else {
+            uint8_t arity = closinfo >> 56;
+            int offset = (arity == 0 || arity == 1) ? 0 : 2;
+            lldb::addr_t full_app_code_ptr =
+                process->ReadPointerFromMemory(value + offset * 8, error);
+            if (error.Fail()) {
+              s->Printf("<could not read full application code pointer from "
+                        "closure>@");
+            } else {
+              Target *target = exe_ctx.GetTargetPtr();
+              Address addr;
+              if (addr.SetLoadAddress(full_app_code_ptr, target)) {
+                addr.Dump(s, exe_ctx_scope,
+                          is_lazy_closure
+                              ? Address::DumpStyleNoFunctionName
+                              : Address::DumpStyleResolvedDescription,
+                          Address::DumpStyleFileAddress, 8, false);
+                print_default = false;
+              } else {
+                s->Printf("<%sclosure, code ptr %p unresolved>",
+                          tag == 247 ? "" : "infix ",
+                          (void *)full_app_code_ptr);
+              }
+            }
+          }
+          break;
+        }
+
+        case 248: // Object_tag
+          s->Printf("<object>@");
+          break;
+
+        case 250: { // Forward_tag
+          lldb::addr_t forward_ptr =
+              process->ReadPointerFromMemory(value, error);
+          if (error.Fail()) {
+            s->Printf("<could not read forwarding pointer>@");
+          } else {
+            offset_t offset = 0;
+            DataExtractor field_data(&forward_ptr, 8, process->GetByteOrder(),
+                                     8);
+            (void)FormatOCamlValue(field_data, s, offset, base_addr,
+                                   exe_ctx_scope, pointers_seen, depth);
+            print_default = false;
+          }
+          break;
+        }
+
+        case 251: // Abstract_tag
+          s->Printf("<abstract|%" PRIu64 " words>@", wosize);
+          break;
+
+        case 252: { // String_tag
+          uint64_t last_word = process->ReadUnsignedIntegerFromMemory(
+              value + (wosize - 1) * 8, 8, 0, error);
+          if (error.Fail()) {
+            s->Printf("<could not read string length>@");
+          } else {
+            // CR mshinwell: endianness!
+            uint8_t last_byte = last_word >> 56;
+            uint64_t string_length = wosize * 8 - last_byte - 1;
+
+            if (string_length > 100) {
+              s->Printf("<long string>@");
+            } else {
+              std::vector<uint8_t> str;
+              size_t bytes_read;
+
+              str.resize(string_length + 1);
+
+              bytes_read =
+                  process->ReadMemory(value, &str.front(), str.size(), error);
+
+              if (error.Fail() || bytes_read < string_length) {
+                s->Printf("<could not read string>@");
+              } else {
+                const char *c_str = (const char *)&str.front();
+                if (strlen(c_str) == string_length) {
+                  /* String does not contain NUL characters */
+                  s->Printf("\"%s\"", c_str);
+                } else {
+                  s->Printf("\"");
+                  DataExtractor cstr_data(&str.front(), str.size(),
+                                          process->GetByteOrder(), 8);
+                  DumpDataExtractor(cstr_data, s, 0, lldb::eFormatChar, 1,
+                                    string_length, UINT32_MAX,
+                                    LLDB_INVALID_ADDRESS, 0, 0);
+                  s->Printf("\"");
+                }
+                print_default = false;
+              }
+            }
+          }
+          break;
+        }
+
+        case 253: { // Double_tag
+          union {
+            double f;
+            uint64_t i;
+          } u;
+          u.i = process->ReadUnsignedIntegerFromMemory(value, 8, 0, error);
+          if (error.Fail()) {
+            s->Printf("<could not read float>@");
+          } else {
+            // CR mshinwell: should probably use proper float printing code
+            // elsewhere in this file
+            s->Printf("%g", u.f);
+            print_default = false;
+          }
+          break;
+        }
+
+        case 254: { // Double_array_tag
+          // N.B. Empty float arrays have tag zero
+          uint64_t wosize_to_print = wosize <= 10 ? wosize : 10;
+          s->Printf("[|");
+          for (uint64_t field = 0; field < wosize_to_print; field++) {
+            union {
+              double f;
+              uint64_t i;
+            } u;
+            u.i = process->ReadUnsignedIntegerFromMemory(value, 8, 0, error);
+            if (error.Fail()) {
+              s->Printf("<could not read floatarray field %" PRIu64 ">", field);
+            } else {
+              // CR mshinwell: should probably use proper float printing code
+              // elsewhere in this file
+              s->Printf("%g", u.f);
+            }
+
+            if (field < wosize_to_print - 1)
+              s->Printf(", ");
+          }
+          if (wosize_to_print < wosize) {
+            s->Printf(", <%" PRIu64 " more elements in floatarray>",
+                      wosize - wosize_to_print);
+          }
+          s->Printf("|]");
+
+          if (!error.Fail())
+            print_default = false;
+          break;
+        }
+
+        case 255: { // Custom_tag
+          lldb::addr_t struct_custom_operations =
+              process->ReadPointerFromMemory(value, error);
+          if (error.Fail()) {
+            s->Printf("<could not read struct custom_operations pointer from "
+                      "custom block>@");
+          } else {
+            lldb::addr_t identifier =
+                process->ReadPointerFromMemory(struct_custom_operations, error);
+            if (error.Fail()) {
+              s->Printf("<could not read identifier pointer from struct "
+                        "custom_operations in custom block>@");
+            } else {
+              std::string identifier_str;
+              (void)process->ReadCStringFromMemory(identifier, identifier_str,
+                                                   error);
+              if (error.Fail()) {
+                s->Printf(
+                    "<could not read identifier string from pointer in struct "
+                    "custom_operations in custom block>@");
+              } else {
+                int int_size = 0;
+                std::string suffix;
+
+                if (identifier_str == "_i") {
+                  /* Int32.t */
+                  int_size = 32;
+                  suffix = "l";
+                } else if (identifier_str == "_j") {
+                  /* Int64.t */
+                  int_size = 64;
+                  suffix = "L";
+                } else if (identifier_str == "_n") {
+                  /* Nativeint.t */
+                  int_size = 64;
+                  suffix = "n";
+                }
+
+                if (int_size != 0) {
+                  uint64_t i = process->ReadUnsignedIntegerFromMemory(
+                      value + 8, 8, 0, error);
+                  if (error.Fail()) {
+                    s->Printf("<custom \"%s\" (could not read data field for "
+                              "integer of kind '%s')>@",
+                              identifier_str.c_str(), suffix.c_str());
+                  } else {
+                    if (int_size == 32)
+                      s->Printf("%ld", (long)i);
+                    else
+                      s->Printf("%lld", (int64_t)i);
+                    s->Printf("%s", suffix.c_str());
+                    print_default = false;
+                  }
+                } else {
+                  if (identifier_str == "_bigarr02") {
+                    lldb::addr_t bigarray_data_ptr =
+                        process->ReadPointerFromMemory(value + 8, error);
+                    uint64_t num_dims = process->ReadUnsignedIntegerFromMemory(
+                        value + 16, 8, 0, error);
+                    if (error.Fail()) {
+                      s->Printf("<bigarray (could not read data and "
+                                "num-dimensions)>@");
+                    } else {
+                      s->Printf("<bigarray%" PRIu64 "|data=%p>", num_dims,
+                                (void *)bigarray_data_ptr);
+                      print_default = false;
+                    }
+                  } else {
+                    // CR mshinwell: check about converting Address.t to (void*)
+                    s->Printf("<custom|\"%s\")>@", identifier_str.c_str());
+                  }
+                }
+              }
+            }
+          }
+          break;
+        }
+
+        default: { // Less than No_scan_tag
+          std::string tag_str;
+          if (tag != 0)
+            tag_str = std::to_string(tag) + ":";
+          if (wosize == 0) {
+            // CR mshinwell: not entirely accurate, but seems likely that the
+            // common case is for this to be an array
+            s->Printf("[| |]");
+            print_default = false;
+          } else if (wosize > 20 || depth >= 2) {
+            s->Printf("%s[...]@", tag_str.c_str());
+          } else {
+            bool failed = false;
+            s->Printf("%s[", tag_str.c_str());
+            for (uint64_t field = 0; field < wosize; field++) {
+              uint64_t field_value = process->ReadUnsignedIntegerFromMemory(
+                  value + field * 8, 8, 0, error);
+              if (error.Fail()) {
+                s->Printf("<could not read field %" PRIu64 ">", field);
+                failed = true;
+              } else {
+                offset_t offset = 0;
+                DataExtractor field_data(&field_value, 8,
+                                         process->GetByteOrder(), 8);
+                (void)FormatOCamlValue(field_data, s, offset, base_addr,
+                                       exe_ctx_scope, pointers_seen, depth + 1);
+                if (field < wosize - 1)
+                  s->Printf(", ");
+              }
+            }
+            s->Printf("]");
+            if (!failed)
+              print_default = false;
+          }
+          break;
+        }
+        }
+      }
+
+      if (print_default)
+        offset = DumpDataExtractor(DE, s, start_offset, eFormatPointer, 8, 1, 1,
+                                   base_addr, 0, 0);
+    }
+  }
+
+  return offset;
+}
+
 lldb::offset_t lldb_private::DumpDataExtractor(
     const DataExtractor &DE, Stream *s, offset_t start_offset,
     lldb::Format item_format, size_t item_byte_size, size_t item_count,
@@ -865,16 +1198,9 @@ lldb::offset_t lldb_private::DumpDataExtractor(
       break;
 
     case eFormatOCamlValue: {
-      uint64_t value = DE.GetU64(&offset);
-      if ((value & 0x1) == 0) {
-        /* Pointer */
-        offset =
-          DumpDataExtractor(DE, s, start_offset, eFormatPointer, 8, 1,
-                            1, base_addr, 0, 0);
-      } else {
-        /* Tagged immediate */
-        s->Printf("%" PRId64, value >> 1);
-      }
+      llvm::DenseSet<lldb::addr_t> pointers_seen;
+      offset = FormatOCamlValue(DE, s, offset, base_addr, exe_scope,
+                                pointers_seen, 0);
       break;
     }
     }

--- a/lldb/source/Core/DumpDataExtractor.cpp
+++ b/lldb/source/Core/DumpDataExtractor.cpp
@@ -863,6 +863,20 @@ lldb::offset_t lldb_private::DumpDataExtractor(
                             item_byte_size / 16, LLDB_INVALID_ADDRESS, 0, 0);
       s->PutChar('}');
       break;
+
+    case eFormatOCamlValue: {
+      uint64_t value = DE.GetU64(&offset);
+      if ((value & 0x1) == 0) {
+        /* Pointer */
+        offset =
+          DumpDataExtractor(DE, s, start_offset, eFormatPointer, 8, 1,
+                            1, base_addr, 0, 0);
+      } else {
+        /* Tagged immediate */
+        s->Printf("%" PRId64, value >> 1);
+      }
+      break;
+    }
     }
   }
 

--- a/lldb/source/DataFormatters/FormatManager.cpp
+++ b/lldb/source/DataFormatters/FormatManager.cpp
@@ -71,6 +71,7 @@ static constexpr FormatInfo g_format_infos[] = {
     {eFormatInstruction, 'i', "instruction"},
     {eFormatVoid, 'v', "void"},
     {eFormatUnicode8, 'u', "unicode8"},
+    {eFormatOCamlValue, '\0', "ocaml_value"},
 };
 
 static_assert((sizeof(g_format_infos) / sizeof(g_format_infos[0])) ==
@@ -425,6 +426,7 @@ lldb::Format FormatManager::GetSingleItemFormat(lldb::Format vector_format) {
   case eFormatVectorOfSInt16:
   case eFormatVectorOfSInt32:
   case eFormatVectorOfSInt64:
+  case eFormatOCamlValue: /* mshinwell: unsure what this is for */
     return eFormatDecimal;
 
   case eFormatVectorOfUInt8:

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
@@ -541,6 +541,7 @@ static llvm::StringRef GetFormatNameOrEmpty(const RegisterInfo &reg_info) {
   case eFormatBinary:
     return "binary";
   case eFormatDecimal:
+  case eFormatOCamlValue:
     return "decimal";
   case eFormatHex:
     return "hex";


### PR DESCRIPTION
We should consider adding a new `TypeSystem` for OCaml, but for the moment this should suffice.