### PR TITLE
Fixed a few bugs of lld

### DIFF
--- a/lld/ELF/Driver.cpp
+++ b/lld/ELF/Driver.cpp
@@ -2254,7 +2254,7 @@ static std::vector<WrappedSymbol> addWrappedSymbols(opt::InputArgList &args) {
     if (!sym)
       continue;
 
-    // If __wrap_ is lazy force load it - it sym->binding might be
+    // If __wrap_ is lazy force load it - its sym->binding might be
     // weak, in which case the wrapped symbol will not get loaded.
     StringRef wrapName = saver().save("__wrap_" + name);
     Symbol *existingWrap = symtab.find(wrapName);

--- a/lld/ELF/Driver.cpp
+++ b/lld/ELF/Driver.cpp
@@ -315,7 +315,9 @@ void LinkerDriver::addFile(StringRef path, bool withLOption) {
 
 // Add a given library by searching it from input search paths.
 void LinkerDriver::addLibrary(StringRef name) {
-  if (std::optional<std::string> path = searchLibrary(name))
+  if (name.size() > 0 && name[0] == '/')
+    addFile(saver().save(name), /*withLOption=*/true);
+  else if (std::optional<std::string> path = searchLibrary(name))
     addFile(saver().save(*path), /*withLOption=*/true);
   else
     error("unable to find library -l" + name, ErrorTag::LibNotFound, {name});

--- a/lld/ELF/Options.td
+++ b/lld/ELF/Options.td
@@ -714,6 +714,8 @@ def: F<"stats">;
 def: F<"warn-execstack">;
 def: F<"warn-once">;
 def: F<"warn-shared-textrel">;
+def: F<"no-keep-files-mapped">;
+def: F<"no-warn-search-mismatch">;
 def: JoinedOrSeparate<["-"], "G">;
 
 // Hidden option used for testing MIPS multi-GOT implementation.


### PR DESCRIPTION
Added two empty flags for compatibility with gold (`-no-keep-files-mapped` and `-no-warn-search-mismatch`).

Allow local symbols in the global part of a symbol table

Allow -I to pass absolute paths

Fix a bug where wrapped symbol could be weak, in which case it's important to force load them for linking to be done correctly.