### PR TITLE
Add hint about large binary to relocation out of range error

### DIFF
--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -110,6 +110,8 @@ void elf::reportRangeError(uint8_t *loc, const Relocation &rel, const Twine &v,
     hint += "; consider recompiling with -fdebug-types-section to reduce size "
             "of debug sections";
 
+  hint += "; this likely happened because your binary is too big, see https://wiki/x/EQbxK for more info";
+
   errorOrWarn(errPlace.loc + "relocation " + lld::toString(rel.type) +
               " out of range: " + v.str() + " is not in [" + Twine(min).str() +
               ", " + Twine(max).str() + "]" + hint);


### PR DESCRIPTION
When binary gets too big, we end up getting "relocation out of range" errors. They might be confusing to users, so we add a link to wiki that gives details about this error and how to fix it.

**Testing**
I used small assembly code to trigger this error:
```
.section .text
.globl _start
_start:
    jmp far_away

.section .text.far,"ax"
.space 0x80000000
far_away:
    ret
```

Before this change, linker fails with the following error:
```
ld.lld: error: test.o:(.text+0x1): relocation R_X86_64_PC32 out of range: 2147483648 is not in [-2147483648, 2147483647]
```

After this change the error is improved:
```
ld.lld: error: test.o:(.text+0x1): relocation R_X86_64_PC32 out of range: 2147483648 is not in [-2147483648, 2147483647]; this likely happened because your binary is too big, see https://wiki/x/EQbxK for more info
```