### PR TITLE
Better error message when receiving SIGBUS

### DIFF
--- a/llvm/lib/Support/Unix/Signals.inc
+++ b/llvm/lib/Support/Unix/Signals.inc
@@ -45,6 +45,7 @@
 #include "llvm/Support/Program.h"
 #include "llvm/Support/SaveAndRestore.h"
 #include "llvm/Support/raw_ostream.h"
+#include "llvm/Support/PrettyStackTrace.h"
 #include <algorithm>
 #include <string>
 #ifdef HAVE_BACKTRACE
@@ -386,6 +387,12 @@ static void SignalHandler(int Sig) {
       if (auto OldOneShotPipeFunction =
               OneShotPipeSignalFunction.exchange(nullptr))
         return OldOneShotPipeFunction();
+
+    if (Sig == SIGBUS) {
+      llvm::setBugReportMsg("Linker received SIGBUG which most likely means that there "
+                            "is insufficient disk space available. If you think this is "
+                            "not the case, please reach out internally for assistance.\n");
+    }
 
     bool IsIntSig = llvm::is_contained(IntSigs, Sig);
     if (IsIntSig)


### PR DESCRIPTION
While we have a disk space check to avoid getting SIGBUS when writing to mmaped output file, this check is a bit racy as available disk space can go down between this check and actual write. In this feature we add a special handling for SIGBUS, that will change error message from
```
PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/ and include the crash backtrace.
```
to
```
Linker received SIGBUG which most likely means that there is insufficient disk space available. If you think this is not the case, please reach out internally for assistance.
```