### PR TITLE
Add external call conventions for OCaml

### DIFF
--- a/llvm/include/llvm/IR/CallingConv.h
+++ b/llvm/include/llvm/IR/CallingConv.h
@@ -244,6 +244,9 @@ namespace CallingConv {
     /// Calling convention for OCaml
     OCaml = 104,
 
+    /// Special case of the C calling convention for calling from OCaml
+    OCaml_C_Call = 105,
+
     /// The highest possible ID. Must be some 2^k - 1.
     MaxID = 1023
   };

--- a/llvm/lib/Target/X86/X86CallingConv.td
+++ b/llvm/lib/Target/X86/X86CallingConv.td
@@ -735,6 +735,15 @@ def CC_X86_64_OCaml : CallingConv<[
   ]>>
 ]>;
 
+def CC_X86_64_OCaml_C_Call : CallingConv<[
+  // OCaml wraps C calls with another function that transfers stack arguments.
+  // RAX contains the function address, and R12 contains the size of the stack arguments.
+  CCIfType<[i64], CCAssignToReg<[RAX, R12]>>,
+
+  // Follow C convention normally otherwise
+  CCDelegateTo<CC_X86_64_C>
+]>;
+
 def CC_X86_64_GHC : CallingConv<[
   // Promote i8/i16/i32 arguments to i64.
   CCIfType<[i8, i16, i32], CCPromoteToType<i64>>,
@@ -1138,6 +1147,7 @@ def CC_X86_64 : CallingConv<[
   CCIfCC<"CallingConv::X86_RegCall", CCDelegateTo<CC_X86_SysV64_RegCall>>,
   CCIfCC<"CallingConv::X86_INTR", CCCustom<"CC_X86_Intr">>,
   CCIfCC<"CallingConv::OCaml", CCDelegateTo<CC_X86_64_OCaml>>,
+  CCIfCC<"CallingConv::OCaml_C_Call", CCDelegateTo<CC_X86_64_OCaml_C_Call>>,
 
   // Mingw64 and native Win64 use Win64 CC
   CCIfSubtarget<"isTargetWin64()", CCDelegateTo<CC_X86_Win64_C>>,


### PR DESCRIPTION
This PR adds an extra calling convention for calls to C functions from OCaml. It is identical to the C calling convention, except it takes two extra arguments in specified registers for the runtime to transfer stack arguments and actually make the call. See [this PR](https://github.com/oxcaml/oxcaml/pull/4419) for more details.