### PR TITLE
Setup a release action for producing binaries

### DIFF
--- a/.github/workflows/release-oxcaml-binary.yml
+++ b/.github/workflows/release-oxcaml-binary.yml
@@ -67,12 +67,12 @@ jobs:
     - name: Package binaries
       run: |
         cd install
-        tar -czf ../${{ matrix.artifact_name }}-${{ steps.branch.outputs.name }}.tar.gz .
+        tar -czf ../${{ github.event.release.tag_name }}-${{ matrix.artifact_name }}-${{ steps.branch.outputs.name }}.tar.gz .
 
     - name: Upload to release using GitHub CLI
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         gh release upload ${{ github.event.release.tag_name }} \
-          ${{ matrix.artifact_name }}-${{ steps.branch.outputs.name }}.tar.gz \
+          ${{ github.event.release.tag_name }}-${{ matrix.artifact_name }}-${{ steps.branch.outputs.name }}.tar.gz \
           --clobber


### PR DESCRIPTION
This PR adds a release action that compiles LLVM and attaches the resulting binaries to the release. It takes the branch from which the release is made into account and incorporates it into the name of the attached tarball.

It currently uses the following naming format for the binaries: `${{RELEASE_TAG}}-llvm-${{OS}}-${{ARCH}}-${{BRANCH}}`, where `RELEASE_TAG` is the tag of the release, `OS` is currently only Linux, `ARCH` is currently x86 64-bit and aarch64, and `BRANCH` is the source branch of the release. This turns the resulting URLs into: `ocaml-flambda/llvm-project/releases/download/${{ RELEASE_TAG }}/${{BINARY_NAME}}.tar.gz`, where `BINARY_NAME` is the name of the binary described above.

**Testing** I've created an example release here that used the action to produce the binaries: https://github.com/ocaml-flambda/llvm-project/releases/tag/test-release-v7. I've tried out the resulting binary in the following run: https://github.com/ocaml-flambda/llvm-project/actions/runs/16775365155. (These were tried before the name format change discussed below.)