### PR TITLE
Remove unnecessary intrinsic for exception handing in OCaml

### DIFF
--- a/llvm/include/llvm/IR/Intrinsics.td
+++ b/llvm/include/llvm/IR/Intrinsics.td
@@ -1047,7 +1047,6 @@ def int_eh_sjlj_longjmp         : Intrinsic<[], [llvm_ptr_ty], [IntrNoReturn]>;
 def int_eh_sjlj_setup_dispatch  : Intrinsic<[], []>;
 
 def int_eh_ocaml_try : Intrinsic<[llvm_i32_ty], []>;
-def int_eh_ocaml_touch : Intrinsic<[], [llvm_ptr_ty], [IntrHasSideEffects]>;
 
 //===---------------- Generic Variable Attribute Intrinsics----------------===//
 //

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -6293,12 +6293,10 @@ void SelectionDAGBuilder::visitIntrinsicCall(const CallInst &I,
     // handler to give an idea of how control flow would look like to LLVM.
     // (It would be nice to mark the attribute directly in LLVM, but putting
     // it in the IR manually suffices for now.)
+    //
+    // It would also be nice to make this follow the OCaml calling conventions
+    // directly inside LLVM.
     setValue(&I, DAG.getConstant(0, sdl, MVT::i32));
-    return;
-  }
-  case Intrinsic::eh_ocaml_touch: {
-    // A no-op that makes sure its alloca'd pointer argument doesn't get
-    // lowered to a temporary and stays on the stack.
     return;
   }
   case Intrinsic::masked_gather:


### PR DESCRIPTION
With the revised version of [this PR](https://github.com/oxcaml/oxcaml/pull/4476), the intrinsic `eh_ocaml_touch` is not needed anymore. This PR simply removes that.