### PR TITLE
Skip tailcall argument check for OCaml functions

### DIFF
--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -3603,6 +3603,9 @@ void Verifier::verifyMustTailCall(CallInst &CI) {
     return;
   }
 
+  // - The caller and callee prototypes must match.  Pointer types of
+  //   parameters or return types may differ in pointee type, but not
+  //   address space.
   if (!CI.getCalledFunction() || !CI.getCalledFunction()->isIntrinsic()) {
     Check(CallerTy->getNumParams() == CalleeTy->getNumParams(),
           "cannot guarantee tail call due to mismatched parameter counts", &CI);

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -3583,7 +3583,8 @@ void Verifier::verifyMustTailCall(CallInst &CI) {
       CI.getCallingConv() == CallingConv::Tail ||
       CI.getCallingConv() == CallingConv::OCaml) {
     StringRef CCName =
-        CI.getCallingConv() == CallingConv::Tail ? "tailcc" : "swifttailcc";
+        CI.getCallingConv() == CallingConv::Tail ? "tailcc" :
+        CI.getCallingConv() == CallingConv::SwiftTail ? "swifttailcc" : "ocamlcc";
 
     // - Only sret, byval, swiftself, and swiftasync ABI-impacting attributes
     //   are allowed in swifttailcc call

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -3604,8 +3604,10 @@ void Verifier::verifyMustTailCall(CallInst &CI) {
 
   // - The caller and callee prototypes must match.  Pointer types of
   //   parameters or return types may differ in pointee type, but not
-  //   address space.
-  if (!CI.getCalledFunction() || !CI.getCalledFunction()->isIntrinsic()) {
+  //   address space. Note that this is not applicable for OCaml functions,
+  //   since their arguments will not be passed from the stack.
+  if ((!CI.getCalledFunction() || !CI.getCalledFunction()->isIntrinsic()) &&
+      CI.getCallingConv() != CallingConv::OCaml) {
     Check(CallerTy->getNumParams() == CalleeTy->getNumParams(),
           "cannot guarantee tail call due to mismatched parameter counts", &CI);
     for (unsigned I = 0, E = CallerTy->getNumParams(); I != E; ++I) {

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -3580,7 +3580,8 @@ void Verifier::verifyMustTailCall(CallInst &CI) {
   AttributeList CallerAttrs = F->getAttributes();
   AttributeList CalleeAttrs = CI.getAttributes();
   if (CI.getCallingConv() == CallingConv::SwiftTail ||
-      CI.getCallingConv() == CallingConv::Tail) {
+      CI.getCallingConv() == CallingConv::Tail ||
+      CI.getCallingConv() == CallingConv::OCaml) {
     StringRef CCName =
         CI.getCallingConv() == CallingConv::Tail ? "tailcc" : "swifttailcc";
 
@@ -3602,12 +3603,7 @@ void Verifier::verifyMustTailCall(CallInst &CI) {
     return;
   }
 
-  // - The caller and callee prototypes must match.  Pointer types of
-  //   parameters or return types may differ in pointee type, but not
-  //   address space. Note that this is not applicable for OCaml functions,
-  //   since their arguments will not be passed from the stack.
-  if ((!CI.getCalledFunction() || !CI.getCalledFunction()->isIntrinsic()) &&
-      CI.getCallingConv() != CallingConv::OCaml) {
+  if (!CI.getCalledFunction() || !CI.getCalledFunction()->isIntrinsic()) {
     Check(CallerTy->getNumParams() == CalleeTy->getNumParams(),
           "cannot guarantee tail call due to mismatched parameter counts", &CI);
     for (unsigned I = 0, E = CallerTy->getNumParams(); I != E; ++I) {


### PR DESCRIPTION
If a function tail calls another function with a different number of arguments, LLVM will complain about this. However, this is permitted to happen in OCaml via `caml_apply` - see `tail_call_outside` in `tailcall.ml` under Llvmize tests in https://github.com/oxcaml/oxcaml/pull/4507. This PR skips that check for OCaml functions.