### PR TITLE
Remove disk space check

### DIFF
--- a/lld/ELF/Writer.cpp
+++ b/lld/ELF/Writer.cpp
@@ -2800,15 +2800,6 @@ template <class ELFT> void Writer<ELFT>::writeHeader() {
     sec->writeHeaderTo<ELFT>(++sHdrs);
 }
 
-static StringRef parentPathOrDot(StringRef path) {
-  auto parent_path = sys::path::parent_path(path);
-  if (parent_path.empty() && !path.empty() && !sys::path::is_absolute(path)) {
-    return ".";
-  } else {
-    return parent_path;
-  }
-}
-
 // Open a result file.
 template <class ELFT> void Writer<ELFT>::openFile() {
   uint64_t maxSize = config->is64 ? INT64_MAX : UINT32_MAX;
@@ -2829,18 +2820,6 @@ template <class ELFT> void Writer<ELFT>::openFile() {
     flags |= FileOutputBuffer::F_executable;
   if (!config->mmapOutputFile)
     flags |= FileOutputBuffer::F_no_mmap;
-  if (config->mmapOutputFile) {
-    // LLD relies on [fallocate] to mmap the output.
-    // In case there's no space left on the device
-    // it will error with SIGBUS, which is confusing
-    // for users
-    auto ErrOrSpaceInfo = sys::fs::disk_space(parentPathOrDot(config->outputFile));
-    if (!ErrOrSpaceInfo)
-      error("Can't get remaining size on disk");
-    if (ErrOrSpaceInfo.get().free < fileSize)
-        error("failed to open " + config->outputFile + ": " +
-              "No Space Left on Device");
-  }
   Expected<std::unique_ptr<FileOutputBuffer>> bufferOrErr =
       FileOutputBuffer::create(config->outputFile, fileSize, flags);
 

--- a/lld/ELF/Writer.cpp
+++ b/lld/ELF/Writer.cpp
@@ -13,8 +13,6 @@
 #include "Config.h"
 #include "InputFiles.h"
 #include "LinkerScript.h"
-#include "llvm/Support/FileSystem.h"
-#include "llvm/Support/Path.h"
 #include "MapFile.h"
 #include "OutputSections.h"
 #include "Relocations.h"


### PR DESCRIPTION
### Context
We initially added this check because lld received SIGBUS when there was insufficient disk space and produced a very obscure error. We have since added a better error message on SIGBUS: https://github.com/ocaml-flambda/llvm-project/commit/3dbb0fbfbffc008123b3de3b3fc709f30a4ed88e, so this check is no longer absolutely necessary.

### Reason for removal
When forwarding output to `/dev/null` (or any other device), this check ends up firing on `/dev`, which size can be any arbitrary number. We could check for the file type and not fire the check on special files, but considering that we now have better error messages in case of SIGBUS, we can just remove this check.