### PR TITLE
Changes for oxcaml/oxcaml PR5976 (flipping DW_AT_name/DW_AT_linkage_name)

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserOxCaml.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserOxCaml.cpp
@@ -365,17 +365,21 @@ Function *DWARFASTParserOxCaml::ParseFunctionFromDWARF(
            "ParseFunctionFromDWARF: DIE 0x{0:x16} name=\"{1}\" mangled=\"{2}\"",
            die.GetID(), name ? name : "<null>", mangled ? mangled : "<null>");
 
-  // Create the function name. For OCaml, the linkage name is already
-  // human-readable (e.g., "Module.function") and the regular name is the
-  // assembly-level symbol (e.g., "camlModule__function_1_2_code")
+  // For OCaml, DW_AT_name is the source-level name (e.g., "Module.function")
+  // and DW_AT_linkage_name is the mangled assembly symbol (e.g.,
+  // "camlModule__function_1_2_code"). Mangled::SetValue would auto-detect via
+  // GetManglingScheme(), which doesn't recognize OCaml mangling, so we set
+  // both fields explicitly.
+  // TODO(oxcaml): once lldb has an OCaml demangler registered with
+  // Mangled::GetManglingScheme(), revert this to a single SetValue(mangled)
+  // call so demangling happens lazily through the standard path.
   Mangled func_name;
-  if (mangled && strlen(mangled) > 0) {
-    func_name.SetValue(ConstString(mangled));
-  } else if (name && strlen(name) > 0) {
-    func_name.SetValue(ConstString(name));
-  } else {
+  if (name && strlen(name) > 0)
+    func_name.SetDemangledName(ConstString(name));
+  if (mangled && strlen(mangled) > 0)
+    func_name.SetMangledName(ConstString(mangled));
+  if (!func_name)
     return nullptr; // Must have a name
-  }
 
   const user_id_t func_user_id = die.GetID();
 

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFIndex.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFIndex.cpp
@@ -30,9 +30,23 @@ bool DWARFIndex::ProcessFunctionDIE(
   llvm::StringRef name = lookup_info.GetLookupName().GetStringRef();
   FunctionNameType name_type_mask = lookup_info.GetNameTypeMask();
 
+  // For OCaml, DW_AT_linkage_name is the mangled assembly symbol and
+  // DW_AT_name is the source-level name users actually type. lldb has no
+  // OCaml demangler, so when comparing a DIE against user-supplied names we
+  // need the source name; the standard die.GetMangledName() (= linkage name)
+  // would never match.
+  // TODO(oxcaml): remove these OCaml carve-outs once lldb can demangle OCaml
+  // linkage names; die.GetMangledName() will then yield a string that the
+  // standard match logic can handle.
+  const bool is_ocaml =
+      SymbolFileDWARF::GetLanguage(*die.GetCU()) == eLanguageTypeOCaml;
+
   if (!(name_type_mask & eFunctionNameTypeFull)) {
     ConstString name_to_match_against;
-    if (const char *mangled_die_name = die.GetMangledName()) {
+    if (is_ocaml) {
+      if (const char *die_name = die.GetName())
+        name_to_match_against = ConstString(die_name);
+    } else if (const char *mangled_die_name = die.GetMangledName()) {
       name_to_match_against = ConstString(mangled_die_name);
     } else {
       SymbolFileDWARF *symbols = die.GetDWARF();
@@ -59,7 +73,10 @@ bool DWARFIndex::ProcessFunctionDIE(
     return true;
 
   // In case of a full match, we just insert everything we find.
-  if (name_type_mask & eFunctionNameTypeFull && die.GetMangledName() == name)
+  const char *full_match_candidate =
+      is_ocaml ? die.GetName() : die.GetMangledName();
+  if (name_type_mask & eFunctionNameTypeFull && full_match_candidate &&
+      llvm::StringRef(full_match_candidate) == name)
     return callback(die);
 
   // If looking for ObjC selectors, we need to also check if the name is a

--- a/lldb/source/Plugins/SymbolFile/DWARF/ManualDWARFIndex.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/ManualDWARFIndex.cpp
@@ -335,7 +335,17 @@ void ManualDWARFIndex::IndexUnitImpl(DWARFUnit &unit,
           else
             set.function_basenames.Insert(ConstString(name), ref);
 
-          if (!is_method && !mangled_cstr && !is_objc_method)
+          // For OCaml, DW_AT_name is the user-facing source name (e.g.
+          // "Module.function") and DW_AT_linkage_name is the mangled assembly
+          // symbol. lldb has no OCaml demangler, so the standard
+          // function_fullnames entry built from DW_AT_linkage_name below is
+          // not what users will type when setting a breakpoint. Index the
+          // source name as a full name too so that name-based lookups (which
+          // default to eFunctionNameTypeFull) hit it.
+          // TODO(oxcaml): remove the OCaml carve-out once lldb can demangle
+          // OCaml linkage names; the default branch will then suffice.
+          if (!is_method && !is_objc_method &&
+              (!mangled_cstr || cu_language == eLanguageTypeOCaml))
             set.function_fullnames.Insert(ConstString(name), ref);
         }
         if (mangled_cstr) {


### PR DESCRIPTION
## Background

OxCaml currently emits DWARF with the conventions reversed from the spec:

| Attribute | OxCaml emits | Spec convention |
|---|---|---|
| `DW_AT_name` | mangled symbol (`camlModule__function_1_2_code`) | source name |
| `DW_AT_linkage_name` | source name (`Module.function`) | mangled symbol |

This is a workaround. lldb's `Mangled::GetManglingScheme()` doesn't recognise OCaml mangled names (no `_Z`/`_R`/`_D`/`?`/`$s` prefix), so `Mangled::SetValue` would store any OCaml string into `m_demangled` regardless. By putting the source name into the slot lldb labels "mangled" (`DW_AT_linkage_name`), the existing parser path accidentally produces the right user-facing name on `Function` objects, and the index's `function_fullnames` table ends up containing the human-readable name that users actually type.

## Goal

Switch OxCaml to spec-compliant DWARF (`DW_AT_name` = source, `DW_AT_linkage_name` = mangled) without breaking breakpoint-by-name or tab completion. Since lldb still has no OCaml demangler, three coordinated lldb-side carve-outs are needed, each gated on `language == eLanguageTypeOCaml` and each marked with a TODO so they can be reverted once a demangler exists.

The OxCaml change will be made in https://github.com/oxcaml/oxcaml/pull/5976

## Changes

### 1. `DWARFASTParserOxCaml::ParseFunctionFromDWARF`

`lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserOxCaml.cpp`

Replaced `func_name.SetValue(mangled)` (which routes to `m_demangled` because OCaml prefixes aren't recognised) with explicit `SetDemangledName(name)` + `SetMangledName(mangled)`. The resulting `Mangled` object now carries both strings, so `GetName(ePreferDemangled)` returns the source name and `NameMatches` accepts either form.

### 2. `ManualDWARFIndex::IndexUnitImpl`

`lldb/source/Plugins/SymbolFile/DWARF/ManualDWARFIndex.cpp`

Extended the existing "insert `DW_AT_name` into `function_fullnames` when there is no linkage name" branch to also fire when `cu_language == eLanguageTypeOCaml`. Without this, the default `eFunctionNameTypeFull` path looks up the user's input against `function_fullnames`, which would otherwise contain only the mangled symbol — `breakpoint set -n Module.function` would fail to resolve.

### 3. `DWARFIndex::ProcessFunctionDIE`

`lldb/source/Plugins/SymbolFile/DWARF/DWARFIndex.cpp`

Used by `AppleDWARFIndex` and `DebugNamesDWARFIndex` to validate index hits against the user's input. Added an `is_ocaml` flag and used it in two places to prefer `die.GetName()` over `die.GetMangledName()`:

- The non-Full match-candidate selection (otherwise `NameMatchesLookupInfo` compares the user's source name against the mangled symbol via the default substring check, which fails).
- The Full-match equality fast-path (otherwise no DIE is accepted because the linkage name never equals the user's input).

## Notes

- All three sites have `TODO(oxcaml)` comments pointing at the underlying root cause (no OCaml demangler in `Mangled::GetManglingScheme()`).
- `DebugNamesDWARFIndex` itself was not modified; its `m_fallback` to `ManualDWARFIndex` plus the shared `ProcessFunctionDIE` cover it.
- `ConstructDemangledNameFromDWARF` in the OxCaml parser is unchanged and still has a stale comment describing the old emission scheme — left alone since it was outside the requested scope.