### PR TITLE
Fix display of names for inlined frames

### DIFF
--- a/lldb/include/lldb/Symbol/Block.h
+++ b/lldb/include/lldb/Symbol/Block.h
@@ -309,6 +309,14 @@ public:
                               const Declaration *decl_ptr,
                               const Declaration *call_decl_ptr);
 
+  /// Overload that takes a pre-built Mangled. Useful for languages whose
+  /// mangling scheme is not recognised by Mangled::GetManglingScheme(): the
+  /// caller can populate both the demangled and mangled slots explicitly
+  /// instead of relying on prefix-based auto-detection.
+  void SetInlinedFunctionInfo(ConstString name, const Mangled &mangled,
+                              const Declaration *decl_ptr,
+                              const Declaration *call_decl_ptr);
+
   /// Set accessor for the variable list.
   ///
   /// Called by the SymbolFile plug-ins after they have parsed the variable

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -1376,8 +1376,27 @@ size_t SymbolFileDWARF::ParseBlocksRecursive(CompileUnit &comp_unit,
                   call_file.value_or(0)),
               call_line.value_or(0), call_column.value_or(0));
 
-        block->SetInlinedFunctionInfo(name, mangled_name, decl_up.get(),
-                                      call_up.get());
+        // For OCaml, the default char-pointer overload would feed
+        // mangled_name through Mangled::SetValue, which doesn't recognise
+        // OCaml mangling and would route the linkage name into m_demangled.
+        // Backtraces (e.g. "[inlined] camlHello__concat_1_4_code") would then
+        // show the mangled symbol instead of the source name. Build the
+        // Mangled explicitly so both slots are populated correctly.
+        // TODO(oxcaml): drop this carve-out once lldb has an OCaml demangler
+        // registered with Mangled::GetManglingScheme(); the default branch
+        // will then suffice.
+        if (GetLanguage(*die.GetCU()) == eLanguageTypeOCaml) {
+          Mangled inlined_mangled;
+          if (name && name[0] != '\0')
+            inlined_mangled.SetDemangledName(ConstString(name));
+          if (mangled_name && mangled_name[0] != '\0')
+            inlined_mangled.SetMangledName(ConstString(mangled_name));
+          block->SetInlinedFunctionInfo(ConstString(name), inlined_mangled,
+                                        decl_up.get(), call_up.get());
+        } else {
+          block->SetInlinedFunctionInfo(name, mangled_name, decl_up.get(),
+                                        call_up.get());
+        }
       }
 
       ++blocks_added;

--- a/lldb/source/Symbol/Block.cpp
+++ b/lldb/source/Symbol/Block.cpp
@@ -389,6 +389,13 @@ void Block::SetInlinedFunctionInfo(const char *name, const char *mangled,
                                                         call_decl_ptr);
 }
 
+void Block::SetInlinedFunctionInfo(ConstString name, const Mangled &mangled,
+                                   const Declaration *decl_ptr,
+                                   const Declaration *call_decl_ptr) {
+  m_inlineInfoSP = std::make_shared<InlineFunctionInfo>(name, mangled, decl_ptr,
+                                                        call_decl_ptr);
+}
+
 VariableListSP Block::GetBlockVariableList(bool can_create) {
   if (!m_parsed_block_variables) {
     if (m_variable_list_sp.get() == nullptr && can_create) {


### PR DESCRIPTION
This should remove the last known regression after flipping `DW_AT_name` / `DW_AT_linkage_name` in oxcaml.