### PR TITLE
DWARF expression support for OxCaml LLDB

### DIFF
--- a/lldb/source/Plugins/Language/OxCaml/CMakeLists.txt
+++ b/lldb/source/Plugins/Language/OxCaml/CMakeLists.txt
@@ -8,6 +8,7 @@ add_lldb_library(lldbPluginOxCamlLanguage PLUGIN
 
   LINK_LIBS
     lldbCore
+    lldbExpression
     lldbTarget
     lldbUtility
 )

--- a/lldb/source/Plugins/Language/OxCaml/OxCamlFormatters.cpp
+++ b/lldb/source/Plugins/Language/OxCaml/OxCamlFormatters.cpp
@@ -60,6 +60,7 @@
 #include "lldb/Utility/Reference.h"
 #include "lldb/Utility/Status.h"
 #include "lldb/ValueObject/ValueObject.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/FormatVariadic.h"
 #include <algorithm>
@@ -86,49 +87,43 @@ static uint64_t MakeLowBitMask(uint64_t bit_size) {
   return (1ULL << bit_size) - 1ULL;
 }
 
-
 static bool FormatValue(Stream &stream, OxCamlType *type, DataExtractor &data,
-                        lldb::ProcessSP process_sp,
-                        const ExecutionContextRef &exe_ctx_ref);
+                        const OxCamlFormatContext &context,
+                        std::optional<lldb::addr_t> object_address);
 static bool FormatUnboxedBase(Stream &stream,
                               OxCamlUnboxedBaseType *unboxed_type,
-                              DataExtractor &data, lldb::ProcessSP process_sp);
+                              DataExtractor &data);
 static bool FormatFallback(Stream &stream, OxCamlType *type,
-                           DataExtractor &data, lldb::ProcessSP process_sp);
+                           DataExtractor &data);
 static bool FormatEnum(Stream &stream, OxCamlEnumType *enum_type,
-                       DataExtractor &data, lldb::ProcessSP process_sp);
+                       DataExtractor &data);
 static bool FormatPointer(Stream &stream, OxCamlPointerType *ptr_type,
-                          DataExtractor &data, lldb::ProcessSP process_sp,
-                          const ExecutionContextRef &exe_ctx_ref);
+                          DataExtractor &data,
+                          const OxCamlFormatContext &context);
 static bool FormatTypedef(Stream &stream, OxCamlTypedefType *typedef_type,
-                          DataExtractor &data, lldb::ProcessSP process_sp,
-                          const ExecutionContextRef &exe_ctx_ref);
+                          DataExtractor &data,
+                          const OxCamlFormatContext &context,
+                          std::optional<lldb::addr_t> object_address);
 static bool FormatStructure(Stream &stream, OxCamlStructureType *struct_type,
-                            DataExtractor &data, lldb::ProcessSP process_sp,
-                            const ExecutionContextRef &exe_ctx_ref);
+                            DataExtractor &data,
+                            const OxCamlFormatContext &context,
+                            std::optional<lldb::addr_t> object_address);
 static bool FormatPlaceholder(Stream &stream,
                               OxCamlPlaceholderType *placeholder_type,
-                              DataExtractor &data, lldb::ProcessSP process_sp);
+                              DataExtractor &data);
 static bool FormatUnknown(Stream &stream, OxCamlUnknownType *unknown_type,
-                          DataExtractor &data, lldb::ProcessSP process_sp);
+                          DataExtractor &data);
 static bool FormatArray(Stream &stream, OxCamlArrayType *array_type,
-                        DataExtractor &data, lldb::ProcessSP process_sp,
-                        const ExecutionContextRef &exe_ctx_ref);
+                        DataExtractor &data, const OxCamlFormatContext &context,
+                        std::optional<lldb::addr_t> object_address);
+static bool TryFormatRuntimeFloatArray(Stream &stream, lldb::addr_t array_ptr,
+                                       lldb::ProcessSP process_sp);
 
-// Forward declarations for variant functions called from
-// FormatPointer/FormatStructure
-static uint64_t
-CalculateMinimumSizeForDiscriminators(OxCamlStructureType *struct_type);
-static uint64_t EstimatePointerAllocationSize(OxCamlType *type,
-                                              DataExtractor &data);
-static uint64_t ComputeActualPointerSize(OxCamlType *pointed_to,
-                                         lldb::addr_t adjusted_address,
-                                         const DataExtractor &data,
-                                         lldb::ProcessSP process_sp);
 static bool FormatVariantPart(Stream &stream,
                               const OxCamlVariantPart &variant_part,
-                              DataExtractor &data, lldb::ProcessSP process_sp,
-                              const ExecutionContextRef &exe_ctx_ref,
+                              DataExtractor &data,
+                              const OxCamlFormatContext &context,
+                              std::optional<lldb::addr_t> object_address,
                               bool is_ocaml_variant);
 
 // ============================================================================
@@ -173,9 +168,14 @@ bool lldb_private::formatters::oxcaml::OxCamlValue_SummaryProvider(
          "(ptr={0:P})",
          process_sp.get());
 
-  const ExecutionContextRef &exe_ctx_ref = valobj.GetExecutionContextRef();
+  OxCamlFormatContext context{process_sp, valobj.GetExecutionContextRef(),
+                              data.GetByteOrder(), data.GetAddressByteSize()};
 
-  return FormatValue(stream, type, data, process_sp, exe_ctx_ref);
+  // No object address at entry: [data] holds the OCaml value itself
+  // (typically a register-resident tagged pointer). FormatPointer sets the
+  // object address for any pointed-to objects it dereferences.
+  return FormatValue(stream, type, data, context,
+                     /*object_address=*/std::nullopt);
 }
 
 // ============================================================================
@@ -183,7 +183,7 @@ bool lldb_private::formatters::oxcaml::OxCamlValue_SummaryProvider(
 // ============================================================================
 
 static bool FormatFallback(Stream &stream, OxCamlType *type,
-                           DataExtractor &data, lldb::ProcessSP process_sp) {
+                           DataExtractor &data) {
   size_t byte_size = data.GetByteSize();
   if (byte_size == 0) {
     if (type) {
@@ -217,7 +217,7 @@ static bool FormatFallback(Stream &stream, OxCamlType *type,
 
 static bool FormatPlaceholder(Stream &stream,
                               OxCamlPlaceholderType *placeholder_type,
-                              DataExtractor &data, lldb::ProcessSP process_sp) {
+                              DataExtractor &data) {
   OXCAML_EMIT_MARKER(
       stream, "<placeholder>",
       "Cannot format unresolved placeholder type '{0}' (DIE 0x{1:x16})",
@@ -226,7 +226,7 @@ static bool FormatPlaceholder(Stream &stream,
 }
 
 static bool FormatUnknown(Stream &stream, OxCamlUnknownType *unknown_type,
-                          DataExtractor &data, lldb::ProcessSP process_sp) {
+                          DataExtractor &data) {
   OXCAML_EMIT_MARKER(
       stream, "<unknown>",
       "Unsupported DWARF tag 0x{0:x} for type '{1}' (DIE 0x{2:x16})",
@@ -237,7 +237,7 @@ static bool FormatUnknown(Stream &stream, OxCamlUnknownType *unknown_type,
 
 static bool FormatUnboxedBase(Stream &stream,
                               OxCamlUnboxedBaseType *unboxed_type,
-                              DataExtractor &data, lldb::ProcessSP process_sp) {
+                              DataExtractor &data) {
   uint64_t byte_size = unboxed_type->GetByteSize();
   ENSURE(byte_size != 0, stream, "<0-byte base type>",
          "Unboxed base type '{0}' (DIE 0x{1:x}) reports zero byte size",
@@ -299,7 +299,7 @@ static bool FormatUnboxedBase(Stream &stream,
 }
 
 static bool FormatEnum(Stream &stream, OxCamlEnumType *enum_type,
-                       DataExtractor &data, lldb::ProcessSP process_sp) {
+                       DataExtractor &data) {
   uint64_t byte_size = enum_type->GetByteSize();
   OX_ASSERT(byte_size > 0 && byte_size <= helpers::constants::WORD_SIZE,
             "OCaml enum type '{0}' (DIE 0x{1:x}) has size {2} bytes, must be "
@@ -325,9 +325,80 @@ static bool FormatEnum(Stream &stream, OxCamlEnumType *enum_type,
   return true;
 }
 
+// Resolve the byte size of [type] at format time. For structures, evaluates
+// the dynamic DW_AT_byte_size/DW_AT_bit_size against [object_address] (which
+// must be the type's own object address). For arrays, compiler-emitted OxCaml
+// DWARF wraps the DW_TAG_array_type in a reference type and equips the array
+// with DW_AT_count and DW_AT_byte_stride. The count expression reads the OCaml
+// block header wosize; generic runtime array discovery belongs to the
+// ocaml_value formatter, not this typed-array path. For everything else,
+// returns the static byte size.
+static llvm::Expected<uint64_t>
+ResolveTypeByteSize(OxCamlType *type,
+                    std::optional<lldb::addr_t> object_address,
+                    const OxCamlFormatContext &context) {
+  OxCamlType *underlying = type;
+  while (underlying && underlying->GetKind() == OxCamlType::Typedef)
+    underlying =
+        static_cast<OxCamlTypedefType *>(underlying)->GetUnderlyingType();
+  if (!underlying)
+    return type->GetByteSize();
+
+  if (underlying->GetKind() == OxCamlType::Structure) {
+    auto *struct_type = static_cast<OxCamlStructureType *>(underlying);
+    auto result =
+        struct_type->GetDynamicSize().Evaluate(context, object_address);
+    if (!result)
+      return result.takeError();
+    OX_ASSERT(
+        result->GetKind() == OxCamlLayoutValueKind::ScalarBytes ||
+            result->GetKind() == OxCamlLayoutValueKind::ScalarBits,
+        "Dynamic size for structure type '{0}' (DIE 0x{1:x}) evaluated to "
+        "layout kind {2}; expected ScalarBytes or ScalarBits",
+        struct_type->GetDisplayName(), struct_type->GetDieId(),
+        static_cast<int>(result->GetKind()));
+    if (result->GetKind() == OxCamlLayoutValueKind::ScalarBits)
+      return (result->GetScalar() + 7) / 8;
+    return result->GetScalar();
+  }
+
+  if (underlying->GetKind() == OxCamlType::Array) {
+    auto *array_type = static_cast<OxCamlArrayType *>(underlying);
+    auto stride_result =
+        array_type->GetStride().Evaluate(context, object_address);
+    if (!stride_result)
+      return stride_result.takeError();
+    OX_ASSERT(stride_result->GetKind() == OxCamlLayoutValueKind::ScalarBytes,
+              "DW_AT_byte_stride for array '{0}' (DIE 0x{1:x}) evaluated to "
+              "layout kind {2}; expected ScalarBytes",
+              array_type->GetDisplayName(), array_type->GetDieId(),
+              static_cast<int>(stride_result->GetKind()));
+    uint64_t stride = stride_result->GetScalar();
+
+    const auto &count = array_type->GetCount();
+    if (!count.has_value())
+      return llvm::createStringError(
+          "Array type '%s' (DIE 0x%" PRIx64
+          ") has no DW_AT_count; compiler-emitted OxCaml arrays must include "
+          "a subrange count expression",
+          array_type->GetDisplayName().c_str(), array_type->GetDieId());
+    auto count_result = count->Evaluate(context, object_address);
+    if (!count_result)
+      return count_result.takeError();
+    OX_ASSERT(count_result->GetKind() == OxCamlLayoutValueKind::ScalarElements,
+              "DW_AT_count for array '{0}' (DIE 0x{1:x}) evaluated to layout "
+              "kind {2}; expected ScalarElements",
+              array_type->GetDisplayName(), array_type->GetDieId(),
+              static_cast<int>(count_result->GetKind()));
+    return count_result->GetScalar() * stride;
+  }
+
+  return type->GetByteSize();
+}
+
 static bool FormatPointer(Stream &stream, OxCamlPointerType *ptr_type,
-                          DataExtractor &data, lldb::ProcessSP process_sp,
-                          const ExecutionContextRef &exe_ctx_ref) {
+                          DataExtractor &data,
+                          const OxCamlFormatContext &context) {
   uint64_t ptr_size = ptr_type->GetByteSize();
   ENSURE(ptr_size == helpers::constants::WORD_SIZE, stream, "<pointer>",
          "OCaml pointer type '{0}' (DIE 0x{1:x}) has size {2} bytes, "
@@ -354,62 +425,65 @@ static bool FormatPointer(Stream &stream, OxCamlPointerType *ptr_type,
          "Pointer 0x{0:x} to '{1}' (DIE 0x{2:x}) lacks a resolved target type",
          ptr_value, ptr_type->GetDisplayName(), ptr_type->GetDieId());
 
-  // Special case: Arrays are variable-sized and need the raw pointer value
-  // Don't dereference - just pass the data (containing pointer) to FormatArray
-  if (pointed_to->GetKind() == OxCamlType::Array) {
-    return FormatArray(stream, static_cast<OxCamlArrayType *>(pointed_to), data,
-                       process_sp, exe_ctx_ref);
+  lldb::addr_t object_address = ptr_value;
+
+  llvm::Expected<uint64_t> actual_size_expected =
+      ResolveTypeByteSize(pointed_to, object_address, context);
+  if (!actual_size_expected) {
+    OXCAML_EMIT_MARKER(
+        stream, "<pointer>",
+        "Failed to evaluate dynamic byte size for pointer 0x{0:x} to "
+        "'{1}' (DIE 0x{2:x}): {3}",
+        ptr_value, pointed_to->GetDisplayName(), pointed_to->GetDieId(),
+        llvm::toString(actual_size_expected.takeError()));
+    return true;
   }
+  uint64_t actual_size = *actual_size_expected;
+  OxCamlType *underlying_pointed_to = pointed_to;
+  while (underlying_pointed_to &&
+         underlying_pointed_to->GetKind() == OxCamlType::Typedef)
+    underlying_pointed_to =
+        static_cast<OxCamlTypedefType *>(underlying_pointed_to)
+            ->GetUnderlyingType();
+  bool is_array_target = underlying_pointed_to &&
+                         underlying_pointed_to->GetKind() == OxCamlType::Array;
 
-  uint64_t size = pointed_to->GetByteSize();
-  ENSURE(size != 0, stream, "<pointer>",
-         "Resolved target type '{0}' (DIE 0x{1:x}) reports byte size 0; "
-         "cannot dereference pointer 0x{2:x}",
-         pointed_to->GetDisplayName(), pointed_to->GetDieId(), ptr_value);
-
-  // potentially offset the pointer for OCaml blocks
-  int64_t base_offset = pointed_to->GetPointerAdjustmentOffset();
-  uint64_t adjusted_address = ptr_value + base_offset;
-
-  uint64_t actual_size =
-      ComputeActualPointerSize(pointed_to, adjusted_address, data, process_sp);
-
-  if (base_offset != 0) {
-    Log *log = GetLog(OxCamlLog::Formatting);
-    LLDB_LOG(log,
-             "FormatPointer: Applying base offset {0} to pointer 0x{1:x}, "
-             "adjusted address: 0x{2:x}, reading {3} bytes",
-             base_offset, ptr_value, adjusted_address, actual_size);
-  }
-
+  // Empty OCaml arrays are real heap blocks with zero-byte payloads. Keep the
+  // zero-size guard for other pointer targets, but let arrays flow through to
+  // FormatArray with an empty DataExtractor and the object address.
   ENSURE(
-      actual_size != 0, stream, "<pointer>",
+      actual_size != 0 || is_array_target, stream, "<pointer>",
       "Resolved target type '{0}' (DIE 0x{1:x}) computed dereference size 0; "
       "cannot dereference pointer 0x{2:x}",
       pointed_to->GetDisplayName(), pointed_to->GetDieId(), ptr_value);
 
   std::vector<uint8_t> buffer(actual_size);
-  Status error;
-  size_t bytes_read = process_sp->ReadMemory(adjusted_address, buffer.data(),
-                                             actual_size, error);
+  DataExtractor pointed_data;
+  pointed_data.SetByteOrder(data.GetByteOrder());
+  pointed_data.SetAddressByteSize(data.GetAddressByteSize());
+  if (actual_size > 0) {
+    Status error;
+    size_t bytes_read = context.process_sp->ReadMemory(
+        object_address, buffer.data(), actual_size, error);
 
-  ENSURE(bytes_read == actual_size && error.Success(), stream, "<pointer>",
-         "Failed to read {0} bytes from address 0x{1:x} for pointer 0x{2:x} "
-         "to '{3}' (DIE 0x{4:x})",
-         actual_size, adjusted_address, ptr_value, pointed_to->GetDisplayName(),
-         pointed_to->GetDieId());
+    ENSURE(bytes_read == actual_size && error.Success(), stream, "<pointer>",
+           "Failed to read {0} bytes from address 0x{1:x} for pointer 0x{2:x} "
+           "to '{3}' (DIE 0x{4:x})",
+           actual_size, object_address, ptr_value, pointed_to->GetDisplayName(),
+           pointed_to->GetDieId());
 
-  DataExtractor pointed_data(buffer.data(), actual_size, data.GetByteOrder(),
-                             data.GetAddressByteSize());
+    pointed_data.SetData(buffer.data(), actual_size, data.GetByteOrder());
+  }
 
-  return FormatValue(stream, pointed_to, pointed_data, process_sp, exe_ctx_ref);
+  return FormatValue(stream, pointed_to, pointed_data, context, object_address);
 }
 
 static bool FormatTypedef(Stream &stream, OxCamlTypedefType *typedef_type,
-                          DataExtractor &data, lldb::ProcessSP process_sp,
-                          const ExecutionContextRef &exe_ctx_ref) {
-  return FormatValue(stream, typedef_type->GetUnderlyingType(), data,
-                     process_sp, exe_ctx_ref);
+                          DataExtractor &data,
+                          const OxCamlFormatContext &context,
+                          std::optional<lldb::addr_t> object_address) {
+  return FormatValue(stream, typedef_type->GetUnderlyingType(), data, context,
+                     object_address);
 }
 
 // Format an OCaml exception value
@@ -550,8 +624,7 @@ ExtractExceptionInfo(lldb::addr_t exception_addr, lldb::ProcessSP process_sp) {
 
 // Format an OCaml exception value
 static bool FormatException(Stream &stream, DataExtractor &data,
-                            lldb::ProcessSP process_sp,
-                            const ExecutionContextRef &exe_ctx_ref) {
+                            const OxCamlFormatContext &context) {
   lldb::offset_t offset = 0;
   uint64_t exception_value = data.GetU64(&offset);
 
@@ -565,7 +638,7 @@ static bool FormatException(Stream &stream, DataExtractor &data,
          exception_value,
          (exception_value == 0) ? "null pointer" : "immediate OCaml value");
 
-  auto info_opt = ExtractExceptionInfo(exception_value, process_sp);
+  auto info_opt = ExtractExceptionInfo(exception_value, context.process_sp);
 
   ENSURE(info_opt.has_value(), stream, "<exception>",
          "Failed to extract OCaml exception payload at 0x{0:x}",
@@ -583,8 +656,9 @@ static bool FormatException(Stream &stream, DataExtractor &data,
       }
 
       DataExtractor arg_data(&info_opt->arguments[i], constants::WORD_SIZE,
-                             process_sp->GetByteOrder(), constants::WORD_SIZE);
-      oxcaml::FormatOxCamlValue(stream, arg_data, process_sp, exe_ctx_ref);
+                             context.byte_order, constants::WORD_SIZE);
+      oxcaml::FormatOxCamlValue(stream, arg_data, context.process_sp,
+                                context.exe_ctx_ref);
     }
 
     if (use_parens) {
@@ -595,161 +669,296 @@ static bool FormatException(Stream &stream, DataExtractor &data,
   return true;
 }
 
-static bool FormatArray(Stream &stream, OxCamlArrayType *array_type,
-                        DataExtractor &data, lldb::ProcessSP process_sp,
-                        const ExecutionContextRef &exe_ctx_ref) {
-  ENSURE(data.GetByteSize() >= helpers::constants::WORD_SIZE, stream, "<array>",
-         "Data size {0} < expected word size {1}", data.GetByteSize(),
-         helpers::constants::WORD_SIZE);
-
-  lldb::offset_t offset = 0;
-  uint64_t array_ptr = data.GetU64(&offset);
-
-  ENSURE(offset != 0, stream, "<array>",
-         "Failed to read OCaml array pointer from value data ({0} bytes "
-         "available)",
-         data.GetByteSize());
-
-  // Check for null or immediate values (not actual pointers)
-  ENSURE(array_ptr != 0 && !helpers::value::IsImmediate(array_ptr), stream,
-         llvm::formatv("<array@0x{0:x}>", array_ptr).str(),
-         "Array pointer 0x{0:x} is a {1}; skipping dereference", array_ptr,
-         array_ptr == 0 ? "null pointer" : "immediate OCaml value");
-
+// Polymorphic array values such as ['a array] may have an ocaml_value element
+// type in DWARF but actually carry unboxed doubles at runtime. The OCaml block
+// tag (Double_array_tag) is authoritative, so check it here before formatting
+// elements from DWARF. Returns true (with output emitted) if the runtime tag
+// proves this is a float array; returns false without emitting anything
+// otherwise.
+static bool TryFormatRuntimeFloatArray(Stream &stream, lldb::addr_t array_ptr,
+                                       lldb::ProcessSP process_sp) {
   auto header_opt = helpers::ReadBlockHeader(array_ptr, process_sp);
-  ENSURE(header_opt.has_value(), stream,
-         llvm::formatv("<array@0x{0:x}>", array_ptr).str(),
-         "Failed to read OCaml array header for pointer 0x{0:x}", array_ptr);
+  if (!header_opt.has_value())
+    return false;
 
-  uint64_t header = *header_opt;
   uint8_t tag;
   uint64_t wosize;
   uint8_t reserved;
-  helpers::header::ParseHeader(header, tag, wosize, reserved);
+  helpers::header::ParseHeader(*header_opt, tag, wosize, reserved);
+  if (tag != helpers::constants::DOUBLE_ARRAY_TAG)
+    return false;
 
-  // OCaml float arrays (tag 254) store unboxed 8-byte IEEE 754 doubles
-  // wosize is the number of doubles (1 word = 1 double on 64-bit platforms)
-  if (tag == constants::DOUBLE_ARRAY_TAG) {
-    return oxcaml::FormatOxCamlDoubleArray(stream, array_ptr, wosize,
-                                           process_sp);
+  return oxcaml::FormatOxCamlDoubleArray(stream, array_ptr, wosize, process_sp);
+}
+
+static bool FormatArray(Stream &stream, OxCamlArrayType *array_type,
+                        DataExtractor &data, const OxCamlFormatContext &context,
+                        std::optional<lldb::addr_t> object_address) {
+  if (object_address.has_value() &&
+      TryFormatRuntimeFloatArray(stream, *object_address, context.process_sp))
+    return true;
+
+  llvm::Expected<OxCamlLayoutResult> stride_result =
+      array_type->GetStride().Evaluate(context, object_address);
+  if (!stride_result) {
+    OXCAML_EMIT_MARKER(
+        stream, "<array>",
+        "Failed to evaluate byte_stride for array '{0}' (DIE 0x{1:x}): {2}",
+        array_type->GetDisplayName(), array_type->GetDieId(),
+        llvm::toString(stride_result.takeError()));
+    return true;
   }
+  uint64_t stride = stride_result->GetScalar();
+  ENSURE(stride != 0, stream, "<array>",
+         "Array type '{0}' (DIE 0x{1:x}) has stride 0; cannot format elements",
+         array_type->GetDisplayName(), array_type->GetDieId());
 
-  // Regular arrays: calculate number of elements from wosize and stride
-  // wosize is number of words, total bytes = wosize * WORD_SIZE
+  // OxCaml compiler-emitted array DIEs always carry DW_AT_count on their
+  // subrange. Values without typed-array DWARF are handled by generic
+  // ocaml_value formatting instead.
+  ENSURE(array_type->GetCount().has_value(), stream, "<array>",
+         "Array type '{0}' (DIE 0x{1:x}) has no DW_AT_count; "
+         "compiler-emitted OxCaml arrays must include a subrange count "
+         "expression",
+         array_type->GetDisplayName(), array_type->GetDieId());
+  llvm::Expected<OxCamlLayoutResult> count_result =
+      array_type->GetCount()->Evaluate(context, object_address);
+  if (!count_result) {
+    OXCAML_EMIT_MARKER(
+        stream, "<array>",
+        "Failed to evaluate DW_AT_count for array '{0}' (DIE 0x{1:x}): {2}",
+        array_type->GetDisplayName(), array_type->GetDieId(),
+        llvm::toString(count_result.takeError()));
+    return true;
+  }
+  uint64_t num_elements = count_result->GetScalar();
+
+  uint64_t payload_size = num_elements * stride;
+  ENSURE(data.GetByteSize() >= payload_size, stream, "<array>",
+         "Array '{0}' (DIE 0x{1:x}) payload buffer holds {2} bytes, needs "
+         "{3} ({4} elements x {5}-byte stride)",
+         array_type->GetDisplayName(), array_type->GetDieId(),
+         data.GetByteSize(), payload_size, num_elements, stride);
+
   OxCamlType *element_type = array_type->GetElementType();
-  uint64_t stride = array_type->GetStride();
-  ENSURE(stride != 0, stream, llvm::formatv("<array@0x{0:x}>", array_ptr).str(),
-         "Array type '{0}' (DIE 0x{1:x}) has stride 0; cannot format array at "
-         "0x{2:x}",
-         array_type->GetDisplayName(), array_type->GetDieId(), array_ptr);
-
-  uint64_t total_bytes = wosize * helpers::constants::WORD_SIZE;
-  uint64_t num_elements = total_bytes / stride;
-  Status error;
-
   stream.Printf("[| ");
-
   for (uint64_t i = 0; i < num_elements; i++) {
     if (i > 0)
       stream.Printf("; ");
 
-    uint64_t element_address = array_ptr + (i * stride);
-
-    std::vector<uint8_t> buffer(stride);
-    size_t bytes_read =
-        process_sp->ReadMemory(element_address, buffer.data(), stride, error);
-
-    if (bytes_read != stride || error.Fail()) {
-      OXCAML_EMIT_MARKER(stream, "<element>",
-                         "Failed to read array element {0} at 0x{1:x}; "
-                         "requested {2} bytes, read {3}",
-                         i, element_address, stride, bytes_read);
-      error.Clear();
-      continue;
-    }
-
-    DataExtractor element_data(buffer.data(), stride, data.GetByteOrder(),
-                               data.GetAddressByteSize());
-    FormatValue(stream, element_type, element_data, process_sp, exe_ctx_ref);
+    DataExtractor element_data(data, i * stride, stride);
+    std::optional<lldb::addr_t> element_address;
+    if (object_address.has_value())
+      element_address = *object_address + i * stride;
+    FormatValue(stream, element_type, element_data, context, element_address);
   }
-
   stream.Printf(" |]");
   return true;
 }
 
-static bool FormatMember(Stream &stream, const OxCamlMember &member,
-                         DataExtractor &data, lldb::ProcessSP process_sp,
-                         const ExecutionContextRef &exe_ctx_ref) {
-  if (member.IsBitField()) {
-    uint64_t bit_offset = member.bit_offset.value();
-    uint64_t bit_size = member.bit_size.value();
-    lldb::offset_t byte_offset = member.data_member_location;
+// A member's location resolved against the parent's object address and the
+// parent's in-buffer data: either an offset within [data] (for constant
+// object-relative locations) or a process load address (for exprloc results).
+// The member object address is the OCaml object address of the member itself,
+// suitable for evaluating expressions on the member's type.
+struct ResolvedMemberLocation {
+  enum class Source { BufferOffset, LoadAddress };
+  Source source;
+  uint64_t buffer_offset = 0;
+  lldb::addr_t load_address = LLDB_INVALID_ADDRESS;
+  std::optional<lldb::addr_t> member_object_address;
+};
 
-    // Check if bit-field spans multiple words (not currently supported)
-    // Multi-word bit-fields would require reading multiple 64-bit words and
-    // combining bits across word boundaries
+static std::optional<ResolvedMemberLocation>
+ResolveMemberLocation(Stream &stream, const OxCamlMember &member,
+                      DataExtractor &data, const OxCamlFormatContext &context,
+                      std::optional<lldb::addr_t> parent_object_address) {
+  (void)data;
+  llvm::Expected<OxCamlLayoutResult> result =
+      member.location.Evaluate(context, parent_object_address);
+  if (!result) {
+    OXCAML_EMIT_MARKER(
+        stream, "<member>", "Failed to evaluate location for member '{0}': {1}",
+        member.name.value_or("<unnamed>"), llvm::toString(result.takeError()));
+    return std::nullopt;
+  }
+
+  ResolvedMemberLocation resolved;
+  if (result->GetLocationStorage() ==
+      OxCamlLayoutResult::LocationStorage::ObjectRelativeByteOffset) {
+    resolved.source = ResolvedMemberLocation::Source::BufferOffset;
+    resolved.buffer_offset = result->GetObjectRelativeByteOffset();
+    if (parent_object_address.has_value())
+      resolved.member_object_address =
+          *parent_object_address + resolved.buffer_offset;
+  } else {
+    resolved.source = ResolvedMemberLocation::Source::LoadAddress;
+    resolved.load_address = result->GetLoadAddress();
+    resolved.member_object_address = resolved.load_address;
+  }
+  return resolved;
+}
+
+// Read [byte_size] bytes for a member or discriminator into [out_buffer]
+// according to a resolved location.
+static bool
+ReadResolvedMemberBytes(Stream &stream, const OxCamlMember &member,
+                        uint64_t byte_size,
+                        const ResolvedMemberLocation &resolved,
+                        DataExtractor &data, const OxCamlFormatContext &context,
+                        llvm::SmallVectorImpl<uint8_t> &out_buffer) {
+  out_buffer.resize(byte_size);
+  if (resolved.source == ResolvedMemberLocation::Source::BufferOffset) {
+    uint64_t offset = resolved.buffer_offset;
+    if (offset + byte_size > data.GetByteSize()) {
+      OXCAML_EMIT_MARKER(
+          stream, "<member>",
+          "Member '{0}' at object-relative offset {1} (+{2} bytes) extends "
+          "past available data ({3} bytes)",
+          member.name.value_or("<unnamed>"), offset, byte_size,
+          data.GetByteSize());
+      return false;
+    }
+    if (data.CopyData(offset, byte_size, out_buffer.data()) != byte_size) {
+      OXCAML_EMIT_MARKER(
+          stream, "<member>",
+          "Member '{0}': failed to copy {1} bytes from offset {2}",
+          member.name.value_or("<unnamed>"), byte_size, offset);
+      return false;
+    }
+    return true;
+  }
+
+  Status error;
+  size_t bytes_read = context.process_sp->ReadMemory(
+      resolved.load_address, out_buffer.data(), byte_size, error);
+  if (bytes_read != byte_size || error.Fail()) {
+    OXCAML_EMIT_MARKER(
+        stream, "<member>",
+        "Member '{0}': failed to read {1} bytes from 0x{2:x}: {3}",
+        member.name.value_or("<unnamed>"), byte_size, resolved.load_address,
+        error.AsCString());
+    return false;
+  }
+  return true;
+}
+
+static bool FormatMember(Stream &stream, const OxCamlMember &member,
+                         DataExtractor &data,
+                         const OxCamlFormatContext &context,
+                         std::optional<lldb::addr_t> object_address) {
+  auto resolved =
+      ResolveMemberLocation(stream, member, data, context, object_address);
+  if (!resolved.has_value())
+    return true;
+
+  if (member.IsBitField()) {
+    llvm::Expected<OxCamlLayoutResult> bit_offset_result =
+        member.bit_offset->Evaluate(context, object_address);
+    if (!bit_offset_result) {
+      OXCAML_EMIT_MARKER(stream, "<bit-field>",
+                         "Failed to evaluate bit offset for member '{0}': {1}",
+                         member.name.value_or("<unnamed>"),
+                         llvm::toString(bit_offset_result.takeError()));
+      return true;
+    }
+    llvm::Expected<OxCamlLayoutResult> bit_size_result =
+        member.bit_size->Evaluate(context, object_address);
+    if (!bit_size_result) {
+      OXCAML_EMIT_MARKER(stream, "<bit-field>",
+                         "Failed to evaluate bit size for member '{0}': {1}",
+                         member.name.value_or("<unnamed>"),
+                         llvm::toString(bit_size_result.takeError()));
+      return true;
+    }
+    uint64_t bit_offset = bit_offset_result->GetScalar();
+    uint64_t bit_size = bit_size_result->GetScalar();
+
     ENSURE(bit_offset + bit_size <= 64, stream, "<bit-field>",
            "Bit-field '{0}' spans multiple words (offset={1}, size={2}); "
            "multi-word bit-fields not yet supported",
            member.name.value_or("<unnamed>"), bit_offset, bit_size);
 
-    ENSURE(byte_offset + sizeof(uint64_t) <= data.GetByteSize(), stream,
-           "<member>",
-           "Not enough data ({0} bytes) to read bit-field '{1}' starting at "
-           "offset {2}",
-           data.GetByteSize(), member.name.value_or("<unnamed>"),
-           static_cast<unsigned>(byte_offset));
+    llvm::SmallVector<uint8_t, 8> word;
+    if (!ReadResolvedMemberBytes(stream, member, sizeof(uint64_t), *resolved,
+                                 data, context, word))
+      return true;
 
-    uint64_t full_value = data.GetU64(&byte_offset);
+    DataExtractor word_data(word.data(), word.size(), data.GetByteOrder(),
+                            data.GetAddressByteSize());
+    lldb::offset_t off = 0;
+    uint64_t full_value = word_data.GetU64(&off);
     uint64_t bit_mask = MakeLowBitMask(bit_size);
     uint64_t extracted = (full_value >> bit_offset) & bit_mask;
 
+    // The extracted bit-field value is a fresh scalar with no header; nested
+    // expressions cannot reference an object address through it.
     DataExtractor bit_data(&extracted, sizeof(extracted), data.GetByteOrder(),
                            data.GetAddressByteSize());
-
-    return FormatValue(stream, member.GetType(), bit_data, process_sp,
-                       exe_ctx_ref);
+    return FormatValue(stream, member.GetType(), bit_data, context,
+                       /*object_address=*/std::nullopt);
   }
 
-  DataExtractor member_data(data, member.data_member_location,
-                            member.GetType()->GetByteSize());
-  return FormatValue(stream, member.GetType(), member_data, process_sp,
-                     exe_ctx_ref);
+  // Resolve the member type's dynamic byte size using the member's own
+  // object address, so nested structures with exprloc-valued sizes read the
+  // right amount of memory.
+  llvm::Expected<uint64_t> member_byte_size_expected = ResolveTypeByteSize(
+      member.GetType(), resolved->member_object_address, context);
+  if (!member_byte_size_expected) {
+    OXCAML_EMIT_MARKER(
+        stream, "<member>",
+        "Failed to evaluate byte size for member '{0}' (type '{1}'): {2}",
+        member.name.value_or("<unnamed>"), member.GetType()->GetDisplayName(),
+        llvm::toString(member_byte_size_expected.takeError()));
+    return true;
+  }
+  uint64_t member_byte_size = *member_byte_size_expected;
+
+  llvm::SmallVector<uint8_t, 32> buffer;
+  if (!ReadResolvedMemberBytes(stream, member, member_byte_size, *resolved,
+                               data, context, buffer))
+    return true;
+
+  DataExtractor member_data(buffer.data(), member_byte_size,
+                            data.GetByteOrder(), data.GetAddressByteSize());
+  return FormatValue(stream, member.GetType(), member_data, context,
+                     resolved->member_object_address);
+}
+
+// Returns true if both members have constant data_member_location 0.
+static bool AreBothMembersAtConstantOffsetZero(const OxCamlMember &a,
+                                               const OxCamlMember &b) {
+  return a.location.IsConstant() && a.location.GetConstant() == 0 &&
+         b.location.IsConstant() && b.location.GetConstant() == 0;
 }
 
 static bool FormatStructure(Stream &stream, OxCamlStructureType *struct_type,
-                            DataExtractor &data, lldb::ProcessSP process_sp,
-                            const ExecutionContextRef &exe_ctx_ref) {
+                            DataExtractor &data,
+                            const OxCamlFormatContext &context,
+                            std::optional<lldb::addr_t> object_address) {
   const auto &members = struct_type->GetMembers();
   const auto &variant_parts = struct_type->GetVariantParts();
 
-  // Special case for OCaml variants: Structures with no direct members and
-  // exactly one variant part are formatted without braces (just the variant
-  // content directly). This represents the typical OCaml variant structure
-  // encoding.
+  // OCaml variant: a structure with no direct members and exactly one
+  // variant part is rendered as the variant content alone (no braces).
   if (members.empty() && variant_parts.size() == 1) {
-    return FormatVariantPart(stream, variant_parts[0], data, process_sp,
-                             exe_ctx_ref, true);
+    return FormatVariantPart(stream, variant_parts[0], data, context,
+                             object_address, true);
   }
 
-  // Special case for OCaml exceptions: Union-style structure with "exn" and
-  // "raw" members. Exceptions have both members at the same offset. We format
-  // only the "raw" member. This hardcodes the current format of the OxCaml
-  // compiler.
+  // OCaml exception: a union-style struct with "exn" and "raw" members both
+  // at offset 0. Format only via FormatException.
   if (members.size() == 2 && variant_parts.empty() &&
       members[0].name.has_value() && members[1].name.has_value() &&
-      members[0].data_member_location == 0 &&
-      members[1].data_member_location == 0) {
+      AreBothMembersAtConstantOffsetZero(members[0], members[1])) {
     const std::string &name0 = members[0].name.value();
     const std::string &name1 = members[1].name.value();
     if ((name0 == "exn" && name1 == "raw") ||
         (name0 == "raw" && name1 == "exn")) {
-      return FormatException(stream, data, process_sp, exe_ctx_ref);
+      return FormatException(stream, data, context);
     }
   }
 
-  // Regular case: structure with members and/or multiple variant parts
-  // Determine formatting based on type
   bool is_tuple = struct_type->IsTuple();
   const char *open_delim = is_tuple ? "(" : "{ ";
   const char *close_delim = is_tuple ? ")" : " }";
@@ -759,7 +968,6 @@ static bool FormatStructure(Stream &stream, OxCamlStructureType *struct_type,
 
   bool has_content = false;
 
-  // Format regular members first
   for (size_t i = 0; i < members.size(); ++i) {
     if (has_content)
       stream.Printf("%s", separator);
@@ -768,16 +976,15 @@ static bool FormatStructure(Stream &stream, OxCamlStructureType *struct_type,
       stream.Printf("%s = ", members[i].name.value().c_str());
     }
 
-    FormatMember(stream, members[i], data, process_sp, exe_ctx_ref);
+    FormatMember(stream, members[i], data, context, object_address);
     has_content = true;
   }
 
-  // Format variant parts
   for (size_t i = 0; i < variant_parts.size(); ++i) {
     if (has_content)
       stream.Printf("%s", separator);
 
-    FormatVariantPart(stream, variant_parts[i], data, process_sp, exe_ctx_ref,
+    FormatVariantPart(stream, variant_parts[i], data, context, object_address,
                       false);
     has_content = true;
   }
@@ -788,118 +995,100 @@ static bool FormatStructure(Stream &stream, OxCamlStructureType *struct_type,
 }
 
 static bool FormatValue(Stream &stream, OxCamlType *type, DataExtractor &data,
-                        lldb::ProcessSP process_sp,
-                        const ExecutionContextRef &exe_ctx_ref) {
+                        const OxCamlFormatContext &context,
+                        std::optional<lldb::addr_t> object_address) {
   if (!type) {
     Log *log = GetLog(OxCamlLog::Formatting);
     LLDB_LOG(
         log,
         "FormatValue: No type information available, using fallback formatter");
-    return FormatFallback(stream, type, data, process_sp);
+    return FormatFallback(stream, type, data);
   }
 
   switch (type->GetKind()) {
   case OxCamlType::Value:
-    return oxcaml::FormatOxCamlValue(stream, data, process_sp, exe_ctx_ref);
+    return oxcaml::FormatOxCamlValue(stream, data, context.process_sp,
+                                     context.exe_ctx_ref);
   case OxCamlType::UnboxedBase:
     return FormatUnboxedBase(stream, static_cast<OxCamlUnboxedBaseType *>(type),
-                             data, process_sp);
+                             data);
   case OxCamlType::Enum:
-    return FormatEnum(stream, static_cast<OxCamlEnumType *>(type), data,
-                      process_sp);
+    return FormatEnum(stream, static_cast<OxCamlEnumType *>(type), data);
   case OxCamlType::Pointer:
     return FormatPointer(stream, static_cast<OxCamlPointerType *>(type), data,
-                         process_sp, exe_ctx_ref);
+                         context);
   case OxCamlType::Typedef:
     return FormatTypedef(stream, static_cast<OxCamlTypedefType *>(type), data,
-                         process_sp, exe_ctx_ref);
+                         context, object_address);
   case OxCamlType::Structure:
     return FormatStructure(stream, static_cast<OxCamlStructureType *>(type),
-                           data, process_sp, exe_ctx_ref);
+                           data, context, object_address);
   case OxCamlType::Array:
     return FormatArray(stream, static_cast<OxCamlArrayType *>(type), data,
-                       process_sp, exe_ctx_ref);
+                       context, object_address);
   case OxCamlType::Placeholder:
     return FormatPlaceholder(stream, static_cast<OxCamlPlaceholderType *>(type),
-                             data, process_sp);
+                             data);
   case OxCamlType::Unknown:
-    return FormatUnknown(stream, static_cast<OxCamlUnknownType *>(type), data,
-                         process_sp);
+    return FormatUnknown(stream, static_cast<OxCamlUnknownType *>(type), data);
   }
   return false;
 }
 
-// ============================================================================
-// Variant Formatting
-// ============================================================================
-//
-// ## Problem Overview
-//
-// OCaml variants present a formatting challenge: the actual memory size of a
-// variant value depends on which constructor is active at runtime. In the
-// current implementation of the OxCaml compiler and the LLDB plugin, the DWARF
-// information only provides static size information (the base structure size),
-// but each variant constructor may have a different payload size.
-//
-// ## Current Approach: Approximate Two-Pass Strategy
-//
-// Since the DWARF doesn't encode dynamic size calculations (which would require
-// DWARF expressions), we use an estimation approach:
-//
-// 1. **First Pass - Read Discriminators**:
-//    - Calculate the minimum memory needed to read all discriminators
-//    - Read enough memory to analyze which variant constructors are active
-//
-// 2. **Second Pass - Estimate Total Size**:
-//    - Based on active variants, calculate the maximum offset required
-//    - This includes: base structure members + active variant member payloads
-//    - Read the estimated total memory needed
-//
-// ## Key Functions:
-//
-// - `ReadDiscriminatorValue()` - Extracts discriminator value from data
-// - `CalculateMinimumSizeForDiscriminators()` - Computes memory needed for
-//   discriminator analysis
-// - `FindActiveVariantsInStructure()` - Determines which variants are active
-//   based on discriminator values
-// - `EstimatePointerAllocationSize()` - Estimates total allocation size by
-//   examining all active variant payloads
-// - `FormatVariantPart()` - Main dispatcher for variant formatting
-// - `FormatVariantPartOxCaml()` - OCaml-style variant formatting
-// - `FormatVariantPartGeneric()` - Generic variant formatting
-//
-// ## Limitations
-//
-// This approach provides an estimate rather than exact sizes:
-// - We calculate the maximum offset across all members in the active variant
-// - Member type sizes may themselves be estimates (e.g., nested structures)
-// - The actual memory layout might be more compact than our calculation
-// suggests
-//
-// A more precise solution would require the OCaml compiler to emit DWARF
-// expressions that dynamically calculate exact sizes based on runtime values.
-//
-// ============================================================================
-
 static std::optional<uint64_t>
-ReadDiscriminatorValue(const OxCamlVariantPart &variant_part,
-                       DataExtractor &data) {
+ReadDiscriminatorValue(Stream &stream, const OxCamlVariantPart &variant_part,
+                       DataExtractor &data, const OxCamlFormatContext &context,
+                       std::optional<lldb::addr_t> object_address) {
   const auto &discriminator = variant_part.GetDiscriminator();
-  lldb::offset_t discr_offset = discriminator.data_member_location;
-
   uint64_t discriminator_byte_size = discriminator.GetType()->GetByteSize();
-
-  std::optional<llvm::APInt> apint =
-      helpers::ExtractAPInt(data, &discr_offset, discriminator_byte_size);
-  if (!apint.has_value() || apint->getBitWidth() > 64) {
+  // The discriminator value is later returned as a uint64_t, so wider
+  // discriminators cannot fit and we refuse to read them here.
+  if (discriminator_byte_size == 0 ||
+      discriminator_byte_size > sizeof(uint64_t))
     return std::nullopt;
-  }
+
+  auto resolved = ResolveMemberLocation(stream, discriminator, data, context,
+                                        object_address);
+  if (!resolved.has_value())
+    return std::nullopt;
+
+  llvm::SmallVector<uint8_t, 8> buffer;
+  if (!ReadResolvedMemberBytes(stream, discriminator, discriminator_byte_size,
+                               *resolved, data, context, buffer))
+    return std::nullopt;
+
+  DataExtractor discr_data(buffer.data(), buffer.size(), data.GetByteOrder(),
+                           data.GetAddressByteSize());
+  lldb::offset_t cursor = 0;
+  std::optional<llvm::APInt> apint =
+      helpers::ExtractAPInt(discr_data, &cursor, discriminator_byte_size);
+  if (!apint.has_value() || apint->getBitWidth() > 64)
+    return std::nullopt;
 
   uint64_t value = apint->getZExtValue();
 
   if (discriminator.IsBitField()) {
-    uint64_t bit_offset = discriminator.bit_offset.value();
-    uint64_t bit_size = discriminator.bit_size.value();
+    Log *log = GetLog(OxCamlLog::Formatting);
+    auto bit_offset_result =
+        discriminator.bit_offset->Evaluate(context, object_address);
+    if (!bit_offset_result) {
+      LLDB_LOG_ERROR(log, bit_offset_result.takeError(),
+                     "ReadDiscriminatorValue: bit_offset evaluation failed for "
+                     "discriminator '{1}': {0}",
+                     discriminator.name);
+      return std::nullopt;
+    }
+    auto bit_size_result =
+        discriminator.bit_size->Evaluate(context, object_address);
+    if (!bit_size_result) {
+      LLDB_LOG_ERROR(log, bit_size_result.takeError(),
+                     "ReadDiscriminatorValue: bit_size evaluation failed for "
+                     "discriminator '{1}': {0}",
+                     discriminator.name);
+      return std::nullopt;
+    }
+    uint64_t bit_offset = bit_offset_result->GetScalar();
+    uint64_t bit_size = bit_size_result->GetScalar();
     if (bit_offset + bit_size > 64)
       return std::nullopt;
     uint64_t discr_mask = MakeLowBitMask(bit_size);
@@ -907,127 +1096,6 @@ ReadDiscriminatorValue(const OxCamlVariantPart &variant_part,
   }
 
   return value;
-}
-
-static uint64_t
-CalculateMinimumSizeForDiscriminators(OxCamlStructureType *struct_type) {
-  uint64_t max_discriminator_end = 0;
-
-  const auto &variant_parts = struct_type->GetVariantParts();
-  for (const auto &variant_part : variant_parts) {
-    const auto &discr = variant_part.GetDiscriminator();
-    uint64_t discr_end =
-        discr.data_member_location + discr.GetType()->GetByteSize();
-    max_discriminator_end = std::max(max_discriminator_end, discr_end);
-  }
-
-  return max_discriminator_end;
-}
-
-static std::vector<const OxCamlVariantPart::Variant *>
-FindActiveVariantsInStructure(OxCamlStructureType *struct_type,
-                              DataExtractor &data) {
-  std::vector<const OxCamlVariantPart::Variant *> active_variants;
-  Log *log = GetLog(OxCamlLog::UserVisibleErrors);
-
-  const auto &variant_parts = struct_type->GetVariantParts();
-  for (const auto &variant_part : variant_parts) {
-    auto discr_value_opt = ReadDiscriminatorValue(variant_part, data);
-    if (!discr_value_opt.has_value()) {
-      LLDB_LOG(log,
-               "Failed to read discriminator value for variant part with "
-               "discriminator '{0}'",
-               variant_part.GetDiscriminator().name);
-      continue; // Skip variant part if discriminator cannot be read
-    }
-
-    auto active_variant = variant_part.GetActiveVariant(*discr_value_opt);
-    if (active_variant.has_value()) {
-      active_variants.push_back(*active_variant);
-    }
-  }
-
-  return active_variants;
-}
-
-static uint64_t EstimatePointerAllocationSize(OxCamlType *type,
-                                              DataExtractor &data) {
-  OX_ASSERT(type != nullptr,
-            "EstimatePointerAllocationSize called with null type (ptr={0:P})",
-            type);
-
-  while (type->GetKind() == OxCamlType::Typedef) {
-    type = static_cast<OxCamlTypedefType *>(type)->GetUnderlyingType();
-  }
-
-  // We assume all types except for structures return accurate sizes. Only
-  // structures can have variant parts.
-  if (type->GetKind() != OxCamlType::Structure) {
-    return type->GetByteSize();
-  }
-
-  auto *struct_type = static_cast<OxCamlStructureType *>(type);
-  uint64_t max_end_offset = type->GetByteSize();
-
-  const auto &members = struct_type->GetMembers();
-  for (const auto &member : members) {
-    // If the size that is returned here is not exact (e.g., as in the case of
-    // structures, then our estimate here is off). That's why it is not exact.
-    uint64_t member_end =
-        member.data_member_location + member.GetType()->GetByteSize();
-    max_end_offset = std::max(max_end_offset, member_end);
-  }
-
-  auto active_variants = FindActiveVariantsInStructure(struct_type, data);
-  for (const auto *variant : active_variants) {
-    for (const auto &member : variant->members) {
-      uint64_t member_end =
-          member.data_member_location + member.GetType()->GetByteSize();
-      max_end_offset = std::max(max_end_offset, member_end);
-    }
-  }
-
-  return max_end_offset;
-}
-
-static uint64_t ComputeActualPointerSize(OxCamlType *pointed_to,
-                                         lldb::addr_t adjusted_address,
-                                         const DataExtractor &data,
-                                         lldb::ProcessSP process_sp) {
-  uint64_t type_size = pointed_to->GetByteSize();
-
-  if (pointed_to->GetKind() != OxCamlType::Structure) {
-    return type_size;
-  }
-
-  auto *struct_type = static_cast<OxCamlStructureType *>(pointed_to);
-  const auto &variant_parts = struct_type->GetVariantParts();
-
-  if (variant_parts.empty()) {
-    return type_size;
-  }
-
-  uint64_t min_discriminator_size =
-      CalculateMinimumSizeForDiscriminators(struct_type);
-  uint64_t temp_read_size = std::max(min_discriminator_size, type_size);
-
-  // Two-pass approach for structures with variant parts:
-  // 1. Read enough data to analyze all discriminators
-  // 2. Calculate precise size based on active variants
-  Status error;
-  std::vector<uint8_t> temp_buffer(temp_read_size);
-  size_t bytes_read = process_sp->ReadMemory(
-      adjusted_address, temp_buffer.data(), temp_buffer.size(), error);
-
-  if (bytes_read >= min_discriminator_size) {
-    DataExtractor heap_data(temp_buffer.data(), bytes_read, data.GetByteOrder(),
-                            data.GetAddressByteSize());
-    uint64_t estimated_size =
-        EstimatePointerAllocationSize(pointed_to, heap_data);
-    return estimated_size;
-  }
-
-  return type_size;
 }
 
 enum VariantKind {
@@ -1038,10 +1106,13 @@ enum VariantKind {
 
 // Format variant part with generic square bracket format:
 // Name[mem1 = val1; ...; memN = valN]
-static bool FormatVariantPartGeneric(
-    Stream &stream, const OxCamlVariantPart &variant_part, DataExtractor &data,
-    lldb::ProcessSP process_sp, const ExecutionContextRef &exe_ctx_ref,
-    uint64_t discr_value, const std::vector<OxCamlMember> &members) {
+static bool FormatVariantPartGeneric(Stream &stream,
+                                     const OxCamlVariantPart &variant_part,
+                                     DataExtractor &data,
+                                     const OxCamlFormatContext &context,
+                                     std::optional<lldb::addr_t> object_address,
+                                     uint64_t discr_value,
+                                     const std::vector<OxCamlMember> &members) {
   std::string discr_name = "Unknown";
   const auto &discriminator = variant_part.GetDiscriminator();
   if (discriminator.GetType()->GetKind() == OxCamlType::Enum) {
@@ -1062,7 +1133,7 @@ static bool FormatVariantPartGeneric(
         stream.Printf("; ");
       if (members[i].name.has_value())
         stream.Printf("%s = ", members[i].name.value().c_str());
-      FormatMember(stream, members[i], data, process_sp, exe_ctx_ref);
+      FormatMember(stream, members[i], data, context, object_address);
     }
     stream.Printf("]");
   }
@@ -1070,10 +1141,13 @@ static bool FormatVariantPartGeneric(
   return true;
 }
 
-static bool FormatVariantPartOxCaml(
-    Stream &stream, const OxCamlVariantPart &variant_part, DataExtractor &data,
-    lldb::ProcessSP process_sp, const ExecutionContextRef &exe_ctx_ref,
-    uint64_t discr_value, const std::vector<OxCamlMember> &members) {
+static bool FormatVariantPartOxCaml(Stream &stream,
+                                    const OxCamlVariantPart &variant_part,
+                                    DataExtractor &data,
+                                    const OxCamlFormatContext &context,
+                                    std::optional<lldb::addr_t> object_address,
+                                    uint64_t discr_value,
+                                    const std::vector<OxCamlMember> &members) {
 
   const auto &discriminator = variant_part.GetDiscriminator();
   ENSURE(discriminator.GetType()->GetKind() == OxCamlType::Enum, stream,
@@ -1150,7 +1224,7 @@ static bool FormatVariantPartOxCaml(
       }
     }
 
-    FormatMember(stream, members[i], data, process_sp, exe_ctx_ref);
+    FormatMember(stream, members[i], data, context, object_address);
   }
 
   stream.Printf("%s", close_delim);
@@ -1158,18 +1232,17 @@ static bool FormatVariantPartOxCaml(
   return true;
 }
 
-// Main variant formatting dispatcher
-//
-// Special handling for artificial discriminators:
-// - Artificial discriminators (e.g., Pointer/Immediate) with exactly one member
-//   in the active variant are displayed transparently (member content only)
-// - All other cases dispatch to either OCaml or generic formatting
+// An artificial discriminator (e.g. Pointer/Immediate) with exactly one
+// member in the active variant is displayed transparently (member content
+// only, no discriminator name or brackets).
 static bool FormatVariantPart(Stream &stream,
                               const OxCamlVariantPart &variant_part,
-                              DataExtractor &data, lldb::ProcessSP process_sp,
-                              const ExecutionContextRef &exe_ctx_ref,
-                              bool is_ocaml_variant = false) {
-  auto discr_value_opt = ReadDiscriminatorValue(variant_part, data);
+                              DataExtractor &data,
+                              const OxCamlFormatContext &context,
+                              std::optional<lldb::addr_t> object_address,
+                              bool is_ocaml_variant) {
+  auto discr_value_opt = ReadDiscriminatorValue(stream, variant_part, data,
+                                                context, object_address);
   ENSURE(discr_value_opt.has_value(), stream, "<variant>",
          "Discriminator value unreadable (variant={0})",
          variant_part.GetDiscriminator().name);
@@ -1183,18 +1256,16 @@ static bool FormatVariantPart(Stream &stream,
 
   const auto &members = (*active_variant)->members;
 
-  // Special case: artificial discriminator with exactly one member
-  // Display the member content directly without discriminator name/brackets
   if (variant_part.HasArtificialDiscriminator() && members.size() == 1) {
-    FormatMember(stream, members[0], data, process_sp, exe_ctx_ref);
+    FormatMember(stream, members[0], data, context, object_address);
     return true;
   }
 
   if (is_ocaml_variant) {
-    return FormatVariantPartOxCaml(stream, variant_part, data, process_sp,
-                                   exe_ctx_ref, discr_value, members);
+    return FormatVariantPartOxCaml(stream, variant_part, data, context,
+                                   object_address, discr_value, members);
   } else {
-    return FormatVariantPartGeneric(stream, variant_part, data, process_sp,
-                                    exe_ctx_ref, discr_value, members);
+    return FormatVariantPartGeneric(stream, variant_part, data, context,
+                                    object_address, discr_value, members);
   }
 }

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserOxCaml.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserOxCaml.cpp
@@ -8,16 +8,22 @@
 
 #include "DWARFASTParserOxCaml.h"
 
+#include "DWARFAttribute.h"
 #include "DWARFDIE.h"
 #include "DWARFDebugInfoEntry.h"
 #include "DWARFDefines.h"
+#include "DWARFFormValue.h"
+#include "DWARFUnit.h"
 #include "SymbolFileDWARF.h"
 #include "llvm/BinaryFormat/Dwarf.h"
 
+#include "lldb/Expression/DWARFExpression.h"
+#include "lldb/Expression/DWARFExpressionList.h"
 #include "lldb/Symbol/Type.h"
 
 #include "../../Language/OxCaml/LogChannelOxCaml.h"
 #include "../../Language/OxCaml/OxCamlAssert.h"
+#include "Plugins/TypeSystem/OxCaml/OxCamlDynamicLayoutValue.h"
 #include "Plugins/TypeSystem/OxCaml/TypeSystemOxCaml.h"
 #include "lldb/Core/Module.h"
 #include "lldb/Symbol/CompileUnit.h"
@@ -29,17 +35,55 @@ using namespace lldb;
 using namespace lldb_private;
 using namespace lldb_private::plugin::dwarf;
 
-// Custom OCaml DWARF attribute DW_AT_ocaml_offset_record_from_pointer
-// This attribute indicates the offset to apply when dereferencing pointers to
-// this type
-static constexpr uint32_t DW_AT_ocaml_offset_record_from_pointer = 0x3106;
-// CR sspies: Technically, this requires an extension of the DWARF
-// standard. If we want to upstream this, we should think about whether the
-// attribute should be on the structure or on the pointer itself (indicating a
-// base offset). For now, we declare it as an ad-hoc attribute here.
-
 // Default size for OCaml values when size attribute is missing
 static constexpr uint64_t DEFAULT_OCAML_VALUE_SIZE = 8;
+
+namespace {
+
+// Locate a single attribute on a DIE and return its form value. Returns
+// std::nullopt if the attribute is absent or the form value cannot be
+// extracted.
+std::optional<DWARFFormValue>
+GetFormValueForAttribute(const DWARFDIE &die, llvm::dwarf::Attribute attr) {
+  DWARFAttributes attrs = die.GetAttributes();
+  for (uint32_t i = 0; i < attrs.Size(); ++i) {
+    if (attrs.AttributeAtIndex(i) != attr)
+      continue;
+    DWARFFormValue form_value;
+    if (!attrs.ExtractFormValueAtIndex(i, form_value))
+      return std::nullopt;
+    return form_value;
+  }
+  return std::nullopt;
+}
+
+// Parse a layout attribute that may be a constant or a DW_FORM_exprloc.
+// The (kind, initial_stack) pair is fixed per attribute by the compiler
+// contract; callers pass the pair that matches the attribute.
+std::optional<OxCamlDynamicLayoutValue> ParseConstantOrExpression(
+    const DWARFDIE &die, llvm::dwarf::Attribute attr,
+    OxCamlLayoutValueKind kind,
+    OxCamlDynamicLayoutValue::InitialStackLayout initial_stack) {
+  auto form_value = GetFormValueForAttribute(die, attr);
+  if (!form_value.has_value())
+    return std::nullopt;
+
+  if (form_value->BlockData() == nullptr)
+    return OxCamlDynamicLayoutValue::MakeConstant(form_value->Unsigned(), kind);
+
+  const DWARFDataExtractor &debug_info_data = die.GetData();
+  uint32_t block_length = form_value->Unsigned();
+  uint32_t block_offset =
+      form_value->BlockData() - debug_info_data.GetDataStart();
+  DataExtractor expr_data(debug_info_data, block_offset, block_length);
+  DWARFExpression expr(expr_data);
+
+  DWARFExpressionList list(die.GetModule(), std::move(expr), die.GetCU());
+  return OxCamlDynamicLayoutValue::MakeExpression(std::move(list), kind,
+                                                  initial_stack);
+}
+
+} // namespace
 
 DWARFASTParserOxCaml::DWARFASTParserOxCaml(TypeSystemOxCaml &oxcaml_typesystem)
     : DWARFASTParser(Kind::DWARFASTParserOxCaml),
@@ -512,31 +556,37 @@ DWARFASTParserOxCaml::ParseStructureType(const SymbolContext &sc,
 
   LLDB_LOG(log, "ParseStructureType: DIE 0x{0:x16}", die_id);
 
-  std::optional<uint64_t> byte_size_opt =
-      die.GetAttributeValueAsOptionalUnsigned(llvm::dwarf::DW_AT_byte_size);
-  if (!byte_size_opt.has_value() || byte_size_opt.value() == 0) {
+  auto size_opt = ParseConstantOrExpression(
+      die, llvm::dwarf::DW_AT_byte_size, OxCamlLayoutValueKind::ScalarBytes,
+      OxCamlDynamicLayoutValue::InitialStackLayout::Empty);
+  if (!size_opt.has_value()) {
+    size_opt = ParseConstantOrExpression(
+        die, llvm::dwarf::DW_AT_bit_size, OxCamlLayoutValueKind::ScalarBits,
+        OxCamlDynamicLayoutValue::InitialStackLayout::Empty);
+  }
+  if (!size_opt.has_value()) {
     LLDB_LOG(log,
-             "ParseStructureType: Missing or zero byte_size for DIE 0x{0:x16}",
+             "ParseStructureType: Missing byte_size and bit_size for DIE "
+             "0x{0:x16}",
              die_id);
     return nullptr;
   }
-  uint64_t byte_size = byte_size_opt.value();
+  OxCamlDynamicLayoutValue size = std::move(*size_opt);
+
+  uint64_t static_size_fallback;
+  if (size.IsConstant()) {
+    if (size.GetConstant() == 0) {
+      LLDB_LOG(log, "ParseStructureType: Zero size for DIE 0x{0:x16}", die_id);
+      return nullptr;
+    }
+    static_size_fallback = size.GetKind() == OxCamlLayoutValueKind::ScalarBits
+                               ? (size.GetConstant() + 7) / 8
+                               : size.GetConstant();
+  } else {
+    static_size_fallback = formatters::oxcaml::helpers::constants::WORD_SIZE;
+  }
 
   std::optional<std::string> name = ExtractTypeName(die);
-
-  auto ocaml_attr = static_cast<llvm::dwarf::Attribute>(
-      DW_AT_ocaml_offset_record_from_pointer);
-  std::optional<uint64_t> attr_value_opt =
-      die.GetAttributeValueAsOptionalUnsigned(ocaml_attr);
-
-  int64_t base_offset = 0;
-  if (attr_value_opt.has_value()) {
-    base_offset = static_cast<int64_t>(attr_value_opt.value());
-    LLDB_LOG(
-        log,
-        "ParseStructureType: Found DW_AT_ocaml_offset_record_from_pointer: {0}",
-        base_offset);
-  }
 
   std::vector<OxCamlMember> members;
   std::vector<OxCamlVariantPart> variant_parts;
@@ -546,11 +596,14 @@ DWARFASTParserOxCaml::ParseStructureType(const SymbolContext &sc,
     case llvm::dwarf::DW_TAG_member: {
       auto member = ParseMember(sc, child_die);
       if (member.has_value()) {
-        members.push_back(std::move(*member));
+        const char *location_kind =
+            member->location.IsConstant() ? "constant" : "expression";
         LLDB_LOG(
-            log, "ParseStructureType: Added member {0} at offset {1}, type {2}",
-            member->name.value_or("<unnamed>"), member->data_member_location,
+            log,
+            "ParseStructureType: Added member {0} ({1} location), type {2}",
+            member->name.value_or("<unnamed>"), location_kind,
             member->GetType()->GetDisplayName());
+        members.push_back(std::move(*member));
       } else {
         LLDB_LOG(log, "ParseStructureType: Failed to parse member, skipping");
       }
@@ -576,12 +629,12 @@ DWARFASTParserOxCaml::ParseStructureType(const SymbolContext &sc,
 
   LLDB_LOG(log,
            "ParseStructureType: Creating OxCamlStructureType with {0} members, "
-           "{1} variant parts, size {2}",
-           members.size(), variant_parts.size(), byte_size);
+           "{1} variant parts, static-size-fallback {2}",
+           members.size(), variant_parts.size(), static_size_fallback);
 
   return std::make_unique<OxCamlStructureType>(
-      die_id, std::move(name), byte_size, std::move(members),
-      std::move(variant_parts), base_offset);
+      die_id, std::move(name), std::move(size), static_size_fallback,
+      std::move(members), std::move(variant_parts));
 }
 
 std::optional<OxCamlMember>
@@ -613,22 +666,24 @@ DWARFASTParserOxCaml::ParseMember(const SymbolContext &sc,
             member_type_die.GetID());
   Reference<OxCamlType> *member_type_ref = member_type_opt.value();
 
-  std::optional<uint64_t> member_offset_opt =
-      member_die.GetAttributeValueAsOptionalUnsigned(
-          llvm::dwarf::DW_AT_data_member_location);
-  if (!member_offset_opt.has_value()) {
+  auto location_opt = ParseConstantOrExpression(
+      member_die, llvm::dwarf::DW_AT_data_member_location,
+      OxCamlLayoutValueKind::Location,
+      OxCamlDynamicLayoutValue::InitialStackLayout::ObjectAddress);
+  if (!location_opt.has_value()) {
     LLDB_LOG(log, "ParseMember: Missing data_member_location for DIE 0x{0:x16}",
              member_die.GetID());
     return std::nullopt;
   }
-  uint64_t member_offset = member_offset_opt.value();
 
-  std::optional<uint64_t> bit_offset =
-      member_die.GetAttributeValueAsOptionalUnsigned(
-          llvm::dwarf::DW_AT_data_bit_offset);
-  std::optional<uint64_t> bit_size =
-      member_die.GetAttributeValueAsOptionalUnsigned(
-          llvm::dwarf::DW_AT_bit_size);
+  auto bit_offset = ParseConstantOrExpression(
+      member_die, llvm::dwarf::DW_AT_data_bit_offset,
+      OxCamlLayoutValueKind::ScalarBits,
+      OxCamlDynamicLayoutValue::InitialStackLayout::Empty);
+  auto bit_size = ParseConstantOrExpression(
+      member_die, llvm::dwarf::DW_AT_bit_size,
+      OxCamlLayoutValueKind::ScalarBits,
+      OxCamlDynamicLayoutValue::InitialStackLayout::Empty);
 
   std::optional<uint64_t> artificial_opt =
       member_die.GetAttributeValueAsOptionalUnsigned(
@@ -636,22 +691,20 @@ DWARFASTParserOxCaml::ParseMember(const SymbolContext &sc,
   bool is_artificial =
       artificial_opt.has_value() && artificial_opt.value() != 0;
 
-  LLDB_LOG(log, "ParseMember: Created member {0} at offset {1}, type {2}{3}",
-           member_name.value_or("<unnamed>"), member_offset,
+  LLDB_LOG(log, "ParseMember: Created member {0} ({1}), type {2}{3}",
+           member_name.value_or("<unnamed>"),
+           location_opt->IsConstant() ? "constant location" : "expr location",
            member_type_ref->get()->GetDisplayName(),
            is_artificial ? " (artificial)" : "");
 
   if (bit_offset.has_value() || bit_size.has_value()) {
-    LLDB_LOG(log, "ParseMember: Bit field detected - offset: {0}, size: {1}",
-             bit_offset.value_or(0), bit_size.value_or(0));
+    LLDB_LOG(log, "ParseMember: Bit field detected for DIE 0x{0:x16}",
+             member_die.GetID());
   }
 
-  return OxCamlMember{std::move(member_name),
-                      member_type_ref,
-                      member_offset,
-                      bit_offset,
-                      bit_size,
-                      is_artificial};
+  return OxCamlMember{std::move(member_name),   member_type_ref,
+                      std::move(*location_opt), std::move(bit_offset),
+                      std::move(bit_size),      is_artificial};
 }
 
 std::optional<OxCamlVariantPart>
@@ -678,8 +731,9 @@ DWARFASTParserOxCaml::ParseVariantPart(const SymbolContext &sc,
     return std::nullopt;
   }
 
-  LLDB_LOG(log, "ParseVariantPart: Discriminator at offset {0}, type: {1}",
-           discriminator_member->data_member_location,
+  LLDB_LOG(log, "ParseVariantPart: Discriminator ({0} location), type: {1}",
+           discriminator_member->location.IsConstant() ? "constant"
+                                                       : "expression",
            discriminator_member->GetType()->GetDisplayName());
 
   std::vector<OxCamlVariantPart::Variant> variants;
@@ -755,40 +809,37 @@ DWARFASTParserOxCaml::ParseArrayType(const SymbolContext &sc,
             element_type_die.GetID());
   Reference<OxCamlType> *element_type_ref = element_type_opt.value();
 
-  std::optional<uint64_t> byte_stride_opt =
-      die.GetAttributeValueAsOptionalUnsigned(llvm::dwarf::DW_AT_byte_stride);
-  uint64_t byte_stride;
-  if (byte_stride_opt.has_value()) {
-    byte_stride = byte_stride_opt.value();
-  } else {
-    byte_stride = element_type_ref->get()->GetByteSize();
-    LLDB_LOG(log,
-             "ParseArrayType: No explicit byte_stride, using element size: {0}",
-             byte_stride);
-  }
+  auto byte_stride_opt = ParseConstantOrExpression(
+      die, llvm::dwarf::DW_AT_byte_stride, OxCamlLayoutValueKind::ScalarBytes,
+      OxCamlDynamicLayoutValue::InitialStackLayout::Empty);
+  OxCamlDynamicLayoutValue byte_stride =
+      byte_stride_opt.has_value() ? std::move(*byte_stride_opt)
+                                  : OxCamlDynamicLayoutValue::MakeConstant(
+                                        element_type_ref->get()->GetByteSize(),
+                                        OxCamlLayoutValueKind::ScalarBytes);
 
-  std::optional<uint64_t> count;
+  std::optional<OxCamlDynamicLayoutValue> count;
   for (DWARFDIE child_die : die.children()) {
     if (child_die.Tag() == llvm::dwarf::DW_TAG_subrange_type) {
-      auto subrange_count_opt = child_die.GetAttributeValueAsOptionalUnsigned(
-          llvm::dwarf::DW_AT_count);
-      if (subrange_count_opt.has_value()) {
-        count = subrange_count_opt.value();
-        LLDB_LOG(log, "ParseArrayType: Found subrange count: {0}",
-                 count.value());
-      }
+      count = ParseConstantOrExpression(
+          child_die, llvm::dwarf::DW_AT_count,
+          OxCamlLayoutValueKind::ScalarElements,
+          OxCamlDynamicLayoutValue::InitialStackLayout::Empty);
       break;
     }
   }
 
   LLDB_LOG(log,
            "ParseArrayType: Creating OxCamlArrayType with element type {0}, "
-           "stride {1}, count {2}",
-           element_type_ref->get()->GetDisplayName(), byte_stride,
-           count.has_value() ? std::to_string(count.value()) : "unknown");
+           "{1} stride, {2} count",
+           element_type_ref->get()->GetDisplayName(),
+           byte_stride.IsConstant() ? "constant" : "expression",
+           count.has_value() ? (count->IsConstant() ? "constant" : "expression")
+                             : "unknown");
 
-  return std::make_unique<OxCamlArrayType>(
-      die_id, std::move(name), element_type_ref, count, byte_stride);
+  return std::make_unique<OxCamlArrayType>(die_id, std::move(name),
+                                           element_type_ref, std::move(count),
+                                           std::move(byte_stride));
 }
 
 std::unique_ptr<OxCamlType>

--- a/lldb/source/Plugins/TypeSystem/OxCaml/CMakeLists.txt
+++ b/lldb/source/Plugins/TypeSystem/OxCaml/CMakeLists.txt
@@ -2,10 +2,12 @@ set(LLVM_LINK_COMPONENTS Support)
 
 add_lldb_library(lldbPluginTypeSystemOxCaml PLUGIN
   TypeSystemOxCaml.cpp
+  OxCamlDynamicLayoutValue.cpp
   OxCamlTypes.cpp
 
   LINK_LIBS
     lldbCore
+    lldbExpression
     lldbSymbol
     lldbTarget
     lldbUtility

--- a/lldb/source/Plugins/TypeSystem/OxCaml/OxCamlDynamicLayoutValue.cpp
+++ b/lldb/source/Plugins/TypeSystem/OxCaml/OxCamlDynamicLayoutValue.cpp
@@ -1,0 +1,181 @@
+//===-- OxCamlDynamicLayoutValue.cpp ----------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "OxCamlDynamicLayoutValue.h"
+
+#include "../../Language/OxCaml/LogChannelOxCaml.h"
+#include "../../Language/OxCaml/OxCamlAssert.h"
+#include "lldb/Core/Value.h"
+#include "lldb/Expression/DWARFExpression.h"
+#include "lldb/Target/RegisterContext.h"
+#include "lldb/Target/StackFrame.h"
+#include "lldb/Utility/Log.h"
+#include "lldb/Utility/Scalar.h"
+#include "llvm/Support/Error.h"
+
+using namespace lldb;
+using namespace lldb_private;
+
+// ============================================================================
+// OxCamlDynamicLayoutValue
+// ============================================================================
+
+OxCamlDynamicLayoutValue
+OxCamlDynamicLayoutValue::MakeConstant(uint64_t value,
+                                       OxCamlLayoutValueKind kind) {
+  return OxCamlDynamicLayoutValue(kind, InitialStackLayout::Empty, value,
+                                  std::nullopt);
+}
+
+OxCamlDynamicLayoutValue
+OxCamlDynamicLayoutValue::MakeExpression(DWARFExpressionList expression,
+                                         OxCamlLayoutValueKind kind,
+                                         InitialStackLayout initial_stack) {
+  return OxCamlDynamicLayoutValue(kind, initial_stack, 0,
+                                  std::move(expression));
+}
+
+static Value MakeObjectAddressValue(lldb::addr_t address) {
+  Value v;
+  v.GetScalar() = address;
+  v.SetValueType(Value::ValueType::Scalar);
+  return v;
+}
+
+// Wrap [error] with an OxCaml-channel log entry and return it. All evaluation
+// failures (DWARF errors, missing object address, kind mismatch) flow through
+// here so every call site gets consistent logging on the user-visible channel.
+// The caller is responsible for emitting a user-visible formatter marker
+// (OXCAML_EMIT_MARKER) when the failure surfaces in formatter output.
+static llvm::Error LogAndReturnError(llvm::Error error) {
+  std::string message = llvm::toString(std::move(error));
+  if (Log *log = GetLog(OxCamlLog::UserVisibleErrors))
+    LLDB_LOG(log, "OxCamlDynamicLayoutValue evaluation failed: {0}", message);
+  return llvm::createStringError(llvm::inconvertibleErrorCode(), message);
+}
+
+llvm::Expected<OxCamlLayoutResult> OxCamlDynamicLayoutValue::Evaluate(
+    const OxCamlFormatContext &context,
+    std::optional<lldb::addr_t> object_address) const {
+  if (IsConstant()) {
+    if (m_kind == OxCamlLayoutValueKind::Location)
+      return OxCamlLayoutResult::MakeObjectRelativeByteOffset(m_constant);
+    return OxCamlLayoutResult::MakeScalar(m_kind, m_constant);
+  }
+
+  ExecutionContext exe_ctx(context.exe_ctx_ref);
+
+  Value initial_value;
+  const Value *initial_value_ptr = nullptr;
+  if (m_initial_stack == InitialStackLayout::ObjectAddress) {
+    if (!object_address.has_value())
+      return LogAndReturnError(llvm::createStringError(
+          "OxCaml dynamic layout expression needs the OCaml object address "
+          "but none is available"));
+    initial_value = MakeObjectAddressValue(*object_address);
+    initial_value_ptr = &initial_value;
+  }
+
+  Value object_address_value;
+  const Value *object_address_ptr = nullptr;
+  if (object_address.has_value()) {
+    object_address_value = MakeObjectAddressValue(*object_address);
+    object_address_ptr = &object_address_value;
+  }
+
+  // Pass the current frame's RegisterContext so DWARF expressions that mention
+  // registers (DW_OP_breg*, DW_OP_regx, etc.) can be evaluated correctly.
+  RegisterContext *reg_ctx = nullptr;
+  if (StackFrame *frame = exe_ctx.GetFramePtr())
+    reg_ctx = frame->GetRegisterContext().get();
+
+  llvm::Expected<Value> result =
+      m_expression->Evaluate(&exe_ctx, reg_ctx,
+                             /*func_load_addr=*/LLDB_INVALID_ADDRESS,
+                             initial_value_ptr, object_address_ptr);
+  if (!result)
+    return LogAndReturnError(result.takeError());
+
+  if (m_kind == OxCamlLayoutValueKind::Location) {
+    if (result->GetValueType() != Value::ValueType::LoadAddress)
+      return LogAndReturnError(llvm::createStringError(
+          "OxCaml location-valued expression did not produce a load address "
+          "(value-type %d); a trailing DW_OP_stack_value would make a "
+          "location-valued attribute scalar by mistake",
+          static_cast<int>(result->GetValueType())));
+    return OxCamlLayoutResult::MakeLoadAddress(
+        result->GetScalar().ULongLong(LLDB_INVALID_ADDRESS));
+  }
+
+  if (result->GetValueType() != Value::ValueType::Scalar)
+    return LogAndReturnError(llvm::createStringError(
+        "OxCaml scalar-valued expression did not produce an implicit scalar "
+        "(value-type %d); did the expression omit DW_OP_stack_value?",
+        static_cast<int>(result->GetValueType())));
+  return OxCamlLayoutResult::MakeScalar(m_kind,
+                                        result->GetScalar().ULongLong());
+}
+
+// ============================================================================
+// OxCamlLayoutResult
+// ============================================================================
+
+OxCamlLayoutResult OxCamlLayoutResult::MakeScalar(OxCamlLayoutValueKind kind,
+                                                  uint64_t scalar) {
+  OX_ASSERT(kind != OxCamlLayoutValueKind::Location,
+            "MakeScalar requires a scalar kind (got {0})",
+            static_cast<int>(kind));
+  return OxCamlLayoutResult(kind, LocationStorage::ObjectRelativeByteOffset,
+                            scalar, LLDB_INVALID_ADDRESS, 0);
+}
+
+OxCamlLayoutResult
+OxCamlLayoutResult::MakeLoadAddress(lldb::addr_t load_address) {
+  return OxCamlLayoutResult(OxCamlLayoutValueKind::Location,
+                            LocationStorage::LoadAddress, 0, load_address, 0);
+}
+
+OxCamlLayoutResult
+OxCamlLayoutResult::MakeObjectRelativeByteOffset(uint64_t byte_offset) {
+  return OxCamlLayoutResult(OxCamlLayoutValueKind::Location,
+                            LocationStorage::ObjectRelativeByteOffset, 0,
+                            LLDB_INVALID_ADDRESS, byte_offset);
+}
+
+uint64_t OxCamlLayoutResult::GetScalar() const {
+  OX_ASSERT(m_kind != OxCamlLayoutValueKind::Location,
+            "GetScalar called on a location-valued result (kind={0})",
+            static_cast<int>(m_kind));
+  return m_scalar;
+}
+
+OxCamlLayoutResult::LocationStorage
+OxCamlLayoutResult::GetLocationStorage() const {
+  OX_ASSERT(m_kind == OxCamlLayoutValueKind::Location,
+            "GetLocationStorage called on a non-location result (kind={0})",
+            static_cast<int>(m_kind));
+  return m_location_storage;
+}
+
+lldb::addr_t OxCamlLayoutResult::GetLoadAddress() const {
+  OX_ASSERT(m_kind == OxCamlLayoutValueKind::Location &&
+                m_location_storage == LocationStorage::LoadAddress,
+            "GetLoadAddress called on a non-load-address result (kind={0}, "
+            "storage={1})",
+            static_cast<int>(m_kind), static_cast<int>(m_location_storage));
+  return m_load_address;
+}
+
+uint64_t OxCamlLayoutResult::GetObjectRelativeByteOffset() const {
+  OX_ASSERT(m_kind == OxCamlLayoutValueKind::Location &&
+                m_location_storage == LocationStorage::ObjectRelativeByteOffset,
+            "GetObjectRelativeByteOffset called on a non-object-relative "
+            "result (kind={0}, storage={1})",
+            static_cast<int>(m_kind), static_cast<int>(m_location_storage));
+  return m_object_relative_byte_offset;
+}

--- a/lldb/source/Plugins/TypeSystem/OxCaml/OxCamlDynamicLayoutValue.h
+++ b/lldb/source/Plugins/TypeSystem/OxCaml/OxCamlDynamicLayoutValue.h
@@ -1,0 +1,154 @@
+//===-- OxCamlDynamicLayoutValue.h ------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_SOURCE_PLUGINS_TYPESYSTEM_OXCAML_OXCAMLDYNAMICLAYOUTVALUE_H
+#define LLDB_SOURCE_PLUGINS_TYPESYSTEM_OXCAML_OXCAMLDYNAMICLAYOUTVALUE_H
+
+#include "../../Language/OxCaml/OxCamlAssert.h"
+#include "lldb/Expression/DWARFExpressionList.h"
+#include "lldb/Target/ExecutionContext.h"
+#include "lldb/lldb-private.h"
+#include "llvm/Support/Error.h"
+#include <cstdint>
+#include <optional>
+
+namespace lldb_private {
+
+class OxCamlLayoutResult;
+
+/// Describes the unit of a dynamic-layout value's result.
+///
+/// - ScalarBits/ScalarBytes/ScalarElements: the value is a scalar quantity
+///   whose unit is fixed by the attribute it came from (e.g. a byte size, a
+///   bit offset, an element count). Scalar exprlocs end with
+///   DW_OP_stack_value.
+/// - Location: the value identifies a memory location. Constants are
+///   object-relative byte offsets; exprlocs evaluate to a load address.
+enum class OxCamlLayoutValueKind {
+  ScalarBits,
+  ScalarBytes,
+  ScalarElements,
+  Location,
+};
+
+/// Session-invariant context for the formatter: process, frame, byte order,
+/// pointer size. Set once at the entry point and threaded by const reference
+/// through recursive calls. Per-recursion state (e.g. the OCaml object
+/// address inherited from an enclosing FormatPointer) is passed as a
+/// separate parameter.
+struct OxCamlFormatContext {
+  lldb::ProcessSP process_sp;
+  ExecutionContextRef exe_ctx_ref;
+  lldb::ByteOrder byte_order;
+  uint32_t address_byte_size;
+};
+
+/// A layout fact that may be a constant or a DWARF expression.
+///
+/// The wrapper is generic over the result's value-kind and the expression's
+/// initial-stack convention. Parsing helpers fix the (kind, initial_stack)
+/// pair per DWARF attribute, since DWARF carries no signal that varies per
+/// occurrence.
+class OxCamlDynamicLayoutValue {
+public:
+  /// What the DWARF evaluator should pre-load on the expression stack before
+  /// running the expression.
+  enum class InitialStackLayout { Empty, ObjectAddress };
+
+  /// Build a constant layout value. For Location kind, the constant is an
+  /// object-relative byte offset.
+  static OxCamlDynamicLayoutValue MakeConstant(uint64_t value,
+                                               OxCamlLayoutValueKind kind);
+
+  static OxCamlDynamicLayoutValue
+  MakeExpression(DWARFExpressionList expression, OxCamlLayoutValueKind kind,
+                 InitialStackLayout initial_stack);
+
+  bool IsConstant() const { return !m_expression.has_value(); }
+  OxCamlLayoutValueKind GetKind() const { return m_kind; }
+  InitialStackLayout GetInitialStack() const { return m_initial_stack; }
+
+  /// Returns the constant value. Asserts when IsConstant() is false, because
+  /// reading the constant out of an expression-valued layout would indicate a
+  /// bug in the caller.
+  uint64_t GetConstant() const {
+    OX_ASSERT(IsConstant(),
+              "GetConstant() called on a non-constant OxCamlDynamicLayoutValue "
+              "(kind={0})",
+              static_cast<int>(m_kind));
+    return m_constant;
+  }
+
+  /// Evaluate the layout value. Constants wrap the stored constant.
+  /// Expressions invoke the LLDB DWARF evaluator with [object_address] as
+  /// the raw OCaml object pointer; evaluation fails cleanly when the
+  /// expression needs an object address (via the initial-stack convention
+  /// or DW_OP_push_object_address) but none is supplied.
+  llvm::Expected<OxCamlLayoutResult>
+  Evaluate(const OxCamlFormatContext &context,
+           std::optional<lldb::addr_t> object_address) const;
+
+private:
+  OxCamlDynamicLayoutValue(OxCamlLayoutValueKind kind,
+                           InitialStackLayout initial_stack, uint64_t constant,
+                           std::optional<DWARFExpressionList> expression)
+      : m_kind(kind), m_initial_stack(initial_stack), m_constant(constant),
+        m_expression(std::move(expression)) {}
+
+  OxCamlLayoutValueKind m_kind;
+  InitialStackLayout m_initial_stack;
+  uint64_t m_constant = 0;
+  std::optional<DWARFExpressionList> m_expression;
+};
+
+/// Tagged result of evaluating an OxCamlDynamicLayoutValue.
+///
+/// The kind drives which accessor is valid:
+/// - ScalarBits/ScalarBytes/ScalarElements: GetScalar() returns the value in
+///   the indicated unit.
+/// - Location: GetLocationStorage() indicates whether the result is an
+///   absolute LoadAddress or an ObjectRelativeByteOffset still to be combined
+///   with the OCaml object pointer.
+///
+/// Misuse is a debug assertion, not a runtime fallback.
+class OxCamlLayoutResult {
+public:
+  enum class LocationStorage { LoadAddress, ObjectRelativeByteOffset };
+
+  static OxCamlLayoutResult MakeScalar(OxCamlLayoutValueKind kind,
+                                       uint64_t scalar);
+  static OxCamlLayoutResult MakeLoadAddress(lldb::addr_t load_address);
+  static OxCamlLayoutResult MakeObjectRelativeByteOffset(uint64_t byte_offset);
+
+  OxCamlLayoutValueKind GetKind() const { return m_kind; }
+
+  uint64_t GetScalar() const;
+
+  LocationStorage GetLocationStorage() const;
+  lldb::addr_t GetLoadAddress() const;
+  uint64_t GetObjectRelativeByteOffset() const;
+
+private:
+  OxCamlLayoutResult(OxCamlLayoutValueKind kind,
+                     LocationStorage location_storage, uint64_t scalar,
+                     lldb::addr_t load_address,
+                     uint64_t object_relative_byte_offset)
+      : m_kind(kind), m_location_storage(location_storage), m_scalar(scalar),
+        m_load_address(load_address),
+        m_object_relative_byte_offset(object_relative_byte_offset) {}
+
+  OxCamlLayoutValueKind m_kind;
+  LocationStorage m_location_storage;
+  uint64_t m_scalar;
+  lldb::addr_t m_load_address;
+  uint64_t m_object_relative_byte_offset;
+};
+
+} // namespace lldb_private
+
+#endif // LLDB_SOURCE_PLUGINS_TYPESYSTEM_OXCAML_OXCAMLDYNAMICLAYOUTVALUE_H

--- a/lldb/source/Plugins/TypeSystem/OxCaml/OxCamlTypes.h
+++ b/lldb/source/Plugins/TypeSystem/OxCaml/OxCamlTypes.h
@@ -10,6 +10,7 @@
 #define LLDB_SOURCE_PLUGINS_TYPESYSTEM_OXCAML_OXCAMLTYPES_H
 
 #include "../../Language/OxCaml/OxCamlHelpers.h"
+#include "OxCamlDynamicLayoutValue.h"
 #include "lldb/Utility/Reference.h"
 #include "lldb/lldb-private.h"
 #include <cstdint>
@@ -48,8 +49,6 @@ public:
   }
 
   virtual uint64_t GetByteSize() const = 0;
-
-  virtual int64_t GetPointerAdjustmentOffset() const { return 0; }
 
   virtual std::string GetDefaultDisplayName() const = 0;
 
@@ -188,20 +187,27 @@ protected:
 
 class OxCamlArrayType : public OxCamlType {
   Reference<OxCamlType> *m_element_type_ref;
-  std::optional<uint64_t> m_count;
-  uint64_t m_stride;
+  /// DW_AT_count, in elements. The storage is optional because DWARF permits
+  /// unbounded arrays, but OxCaml compiler-emitted array DIEs must have a
+  /// subrange count expression that reads the runtime block wosize.
+  std::optional<OxCamlDynamicLayoutValue> m_count;
+  /// DW_AT_byte_stride, in bytes. OxCaml compiler output emits this explicitly.
+  OxCamlDynamicLayoutValue m_stride;
 
 public:
   OxCamlArrayType(lldb::user_id_t die_id, std::optional<std::string> name,
                   Reference<OxCamlType> *element_type_ref,
-                  std::optional<uint64_t> count, uint64_t stride)
+                  std::optional<OxCamlDynamicLayoutValue> count,
+                  OxCamlDynamicLayoutValue stride)
       : OxCamlType(Array, die_id, std::move(name)),
-        m_element_type_ref(element_type_ref), m_count(count), m_stride(stride) {
-  }
+        m_element_type_ref(element_type_ref), m_count(std::move(count)),
+        m_stride(std::move(stride)) {}
 
   OxCamlType *GetElementType() const;
-  std::optional<uint64_t> GetCount() const { return m_count; }
-  uint64_t GetStride() const { return m_stride; }
+  const std::optional<OxCamlDynamicLayoutValue> &GetCount() const {
+    return m_count;
+  }
+  const OxCamlDynamicLayoutValue &GetStride() const { return m_stride; }
   uint64_t GetByteSize() const override {
     return formatters::oxcaml::helpers::constants::WORD_SIZE;
   }
@@ -213,9 +219,14 @@ protected:
 struct OxCamlMember {
   std::optional<std::string> name;
   Reference<OxCamlType> *type_ref;
-  uint64_t data_member_location;
-  std::optional<uint64_t> bit_offset;
-  std::optional<uint64_t> bit_size;
+  /// Object-address-relative location of this member. Constants are byte
+  /// offsets from the raw OCaml object pointer; exprlocs evaluate to a load
+  /// address using the pre-pushed pointer convention.
+  OxCamlDynamicLayoutValue location;
+  /// Optional bit-field offset and size. Both are scalar quantities in bits
+  /// (constants or empty-stack exprlocs).
+  std::optional<OxCamlDynamicLayoutValue> bit_offset;
+  std::optional<OxCamlDynamicLayoutValue> bit_size;
   bool is_artificial = false;
 
   bool IsBitField() const {
@@ -250,34 +261,33 @@ public:
 
 class OxCamlStructureType : public OxCamlType {
 private:
-  uint64_t m_byte_size;
+  /// Dynamic size (ScalarBytes or ScalarBits, constant or expression). The
+  /// unit is recorded by [m_size.GetKind()]; callers that need bytes must
+  /// convert. [m_static_size_fallback] (always in bytes) is used by LLDB
+  /// APIs that need a static size without an execution context.
+  OxCamlDynamicLayoutValue m_size;
+  uint64_t m_static_size_fallback;
   std::vector<OxCamlMember> m_members;
   std::vector<OxCamlVariantPart> m_variant_parts;
 
-  // Custom base offset from DW_AT_ocaml_offset_record_from_pointer. This is
-  // specific to the DWARF encoding used by the OxCaml compiler. It supports an
-  // ad-hoc attribute (see DW_AT_ocaml_offset_record_from_pointer in
-  // DWARFASTParserOxCaml.cpp) that specifies a byte offset to apply when
-  // dealing with a pointer to a structure. This allows one to factor in the
-  // header field of a block when the actual pointer points to the first entry
-  // in the block.
-  int64_t m_base_offset;
-
 public:
   OxCamlStructureType(lldb::user_id_t die_id, std::optional<std::string> name,
-                      uint64_t byte_size, std::vector<OxCamlMember> members,
-                      std::vector<OxCamlVariantPart> variant_parts = {},
-                      int64_t base_offset = 0)
-      : OxCamlType(Structure, die_id, std::move(name)), m_byte_size(byte_size),
+                      OxCamlDynamicLayoutValue size,
+                      uint64_t static_size_fallback,
+                      std::vector<OxCamlMember> members,
+                      std::vector<OxCamlVariantPart> variant_parts = {})
+      : OxCamlType(Structure, die_id, std::move(name)),
+        m_size(std::move(size)),
+        m_static_size_fallback(static_size_fallback),
         m_members(std::move(members)),
-        m_variant_parts(std::move(variant_parts)), m_base_offset(base_offset) {}
+        m_variant_parts(std::move(variant_parts)) {}
 
-  uint64_t GetByteSize() const override { return m_byte_size; }
+  uint64_t GetByteSize() const override { return m_static_size_fallback; }
+  const OxCamlDynamicLayoutValue &GetDynamicSize() const { return m_size; }
   const std::vector<OxCamlMember> &GetMembers() const { return m_members; }
   const std::vector<OxCamlVariantPart> &GetVariantParts() const {
     return m_variant_parts;
   }
-  int64_t GetPointerAdjustmentOffset() const override { return m_base_offset; }
 
   bool IsOCamlVariant() const;
   bool IsTuple() const;

--- a/lldb/source/Plugins/TypeSystem/OxCaml/TypeSystemOxCaml.cpp
+++ b/lldb/source/Plugins/TypeSystem/OxCaml/TypeSystemOxCaml.cpp
@@ -338,8 +338,15 @@ void TypeSystemOxCaml::Dump(llvm::raw_ostream &output, llvm::StringRef filter) {
       auto *at = static_cast<OxCamlArrayType *>(actual_type);
       output << " (array of " << at->GetElementType()->GetDisplayName();
       if (at->GetCount().has_value())
-        output << ", count=" << at->GetCount().value();
-      output << ", stride=" << at->GetStride() << " bytes)";
+        output << ", count="
+               << (at->GetCount()->IsConstant()
+                       ? std::to_string(at->GetCount()->GetConstant())
+                       : std::string("<dynamic>"));
+      output << ", stride="
+             << (at->GetStride().IsConstant()
+                     ? std::to_string(at->GetStride().GetConstant())
+                     : std::string("<dynamic>"))
+             << " bytes)";
     } break;
     case OxCamlType::Placeholder:
       output << " (placeholder - parsing in progress)";


### PR DESCRIPTION
This PR lets the OxCaml formatter evaluate DWARF expressions at format time so the compiler can describe layout facts that depend on the value being formatted—most importantly variant payload sizes that vary by active constructor.

## Motivation

OxCaml's static type model assumed constant member offsets, constant sizes, and constant strides. That assumption broke down for variants: the formatter previously worked around dynamic allocation sizes with a two-pass estimator that inferred a maximum member end offset from the active variant members. The workaround did not match the compiler's actual layout knowledge, and could not express anything that needed process memory (e.g. a size derived from the OCaml block header).

LLDB already has a fully capable DWARF expression evaluator. The right fix is to keep the relevant `DW_FORM_exprloc` attributes around at parse time and evaluate them from the formatter with a live execution context.

## What changes

- **Dynamic layout values.** Layout-bearing attributes (`DW_AT_byte_size`, `DW_AT_bit_size`, `DW_AT_data_member_location`, DW_AT_data_bit_offset`, `DW_AT_count`, `DW_AT_byte_stride`) are stored as either a constant or a DWARF expression, tagged with the kind of result they produce (scalar bits/bytes/elements, or a location) and the initial-stack convention (empty, or pre-loaded with the object pointer).
- **Formatter context.** A small context object is threaded through the recursive formatter so expressions can be evaluated with a real `ExecutionContext`, register context, and module. Raw OCaml object addresses are passed alongside so location-valued expressions and `DW_OP_push_object_address` work.
- **Variant sizing via the compiler.** With the compiler emitting accurate sizes (constant where known, `DW_FORM_exprloc` for tag-dependent payloads), the two-pass discriminator-sizing workaround is removed. The formatter trusts the size attribute.
- **Raw-pointer member-offset convention.** Member offsets and locations are now relative to the raw OCaml object pointer rather than the post-header address. The plugin reads the OCaml block header explicitly at `object_address - WORD_SIZE` when needed.
- **Removed custom attribute handling.** Support for `DW_AT_ocaml_offset_record_from_pointer` (0x3106) is deleted along with the pointer-adjustment path. This is an intentional breaking change paired with the OxCaml compiler PR; old binaries that still emit the legacy attribute are not supported.
- **Malformed-expression handling.** Expression evaluation failures and result-kind mismatches (a location-valued attribute that ends with `DW_OP_stack_value`, or a scalar attribute that returns a memory location) log under the OxCaml formatting category and fall back to the usual formatter error marker rather than fabricating an address.

## Compatibility

Intentionally breaking with binaries produced by older OxCaml compilers that emit `DW_AT_ocaml_offset_record_from_pointer` and the header-relative `DW_AT_data_member_location` convention. The matching compiler change ships in the OxCaml repo.

## Companion PR

**[Companion OxCaml PR](https://github.com/oxcaml/oxcaml/pull/6093)**
