### PR TITLE
Add a demangler for the OxCaml structured mangling scheme

### DIFF
--- a/lldb/include/lldb/Core/Mangled.h
+++ b/lldb/include/lldb/Core/Mangled.h
@@ -43,6 +43,7 @@ public:
     eManglingSchemeNone = 0,
     eManglingSchemeMSVC,
     eManglingSchemeItanium,
+    eManglingSchemeOxCaml,
     eManglingSchemeRustV0,
     eManglingSchemeD,
     eManglingSchemeSwift,

--- a/lldb/source/Core/Mangled.cpp
+++ b/lldb/source/Core/Mangled.cpp
@@ -47,6 +47,9 @@ Mangled::ManglingScheme Mangled::GetManglingScheme(llvm::StringRef const name) {
   if (name.starts_with("?"))
     return Mangled::eManglingSchemeMSVC;
 
+  if (name.starts_with("_Caml"))
+    return Mangled::eManglingSchemeOxCaml;
+
   if (name.starts_with("_R"))
     return Mangled::eManglingSchemeRustV0;
 
@@ -197,6 +200,20 @@ GetItaniumDemangledStr(const char *M) {
   return {demangled_cstr, std::move(info)};
 }
 
+static char *GetOxCamlDemangledStr(llvm::StringRef M) {
+  char *demangled_cstr = llvm::oxcamlDemangle(M);
+
+  if (Log *log = GetLog(LLDBLog::Demangle)) {
+    if (demangled_cstr && demangled_cstr[0])
+      LLDB_LOG(log, "demangled oxcaml: {0} -> \"{1}\"", M, demangled_cstr);
+    else
+      LLDB_LOG(log, "demangled oxcaml: {0} -> error: failed to demangle",
+               static_cast<std::string_view>(M));
+  }
+
+  return demangled_cstr;
+}
+
 static char *GetRustV0DemangledStr(llvm::StringRef M) {
   char *demangled_cstr = llvm::rustDemangle(M);
 
@@ -274,6 +291,7 @@ bool Mangled::GetRichManglingInfo(RichManglingContext &context,
     }
   }
 
+  case eManglingSchemeOxCaml:
   case eManglingSchemeRustV0:
   case eManglingSchemeD:
   case eManglingSchemeSwift:
@@ -324,6 +342,9 @@ ConstString Mangled::GetDemangledNameImpl(bool force) const {
     m_demangled_info.emplace(std::move(demangled.second));
     break;
   }
+  case eManglingSchemeOxCaml:
+    demangled_name = GetOxCamlDemangledStr(m_mangled);
+    break;
   case eManglingSchemeRustV0:
     demangled_name = GetRustV0DemangledStr(m_mangled);
     break;

--- a/lldb/source/Core/Mangled.cpp
+++ b/lldb/source/Core/Mangled.cpp
@@ -47,7 +47,7 @@ Mangled::ManglingScheme Mangled::GetManglingScheme(llvm::StringRef const name) {
   if (name.starts_with("?"))
     return Mangled::eManglingSchemeMSVC;
 
-  if (name.starts_with("_Caml"))
+  if (llvm::isOxCamlMangledName(name))
     return Mangled::eManglingSchemeOxCaml;
 
   if (name.starts_with("_R"))
@@ -201,7 +201,10 @@ GetItaniumDemangledStr(const char *M) {
 }
 
 static char *GetOxCamlDemangledStr(llvm::StringRef M) {
-  char *demangled_cstr = llvm::oxcamlDemangle(M);
+  // Use the stamp-stripped form for display: the trailing compiler stamp is a
+  // non-deterministic counter that hurts breakpoint-by-name and clutters
+  // output; the source location is recovered from DWARF (line table) instead.
+  char *demangled_cstr = llvm::oxcamlDemangleNoStamp(M);
 
   if (Log *log = GetLog(LLDBLog::Demangle)) {
     if (demangled_cstr && demangled_cstr[0])

--- a/lldb/source/Core/Mangled.cpp
+++ b/lldb/source/Core/Mangled.cpp
@@ -201,10 +201,7 @@ GetItaniumDemangledStr(const char *M) {
 }
 
 static char *GetOxCamlDemangledStr(llvm::StringRef M) {
-  // Use the stamp-stripped form for display: the trailing compiler stamp is a
-  // non-deterministic counter that hurts breakpoint-by-name and clutters
-  // output; the source location is recovered from DWARF (line table) instead.
-  char *demangled_cstr = llvm::oxcamlDemangleNoStamp(M);
+  char *demangled_cstr = llvm::oxcamlDemangle(M);
 
   if (Log *log = GetLog(LLDBLog::Demangle)) {
     if (demangled_cstr && demangled_cstr[0])

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserOxCaml.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserOxCaml.cpp
@@ -13,6 +13,9 @@
 #include "DWARFDefines.h"
 #include "SymbolFileDWARF.h"
 #include "llvm/BinaryFormat/Dwarf.h"
+#include "llvm/Demangle/Demangle.h"
+
+#include <cstdlib>
 
 #include "lldb/Symbol/Type.h"
 
@@ -317,18 +320,28 @@ DWARFASTParserOxCaml::CreateLLDBType(const DWARFDIE &die,
 
 ConstString
 DWARFASTParserOxCaml::ConstructDemangledNameFromDWARF(const DWARFDIE &die) {
-  // CR sspies: This function would be the right place to compute OCaml linkage
-  // names from mangled symbol names if they weren't provided via
-  // DW_AT_linkage_name.
+  // Return the source-level name for an OCaml function DIE. This is the single
+  // source of truth used for name-based lookups (see DWARFIndex and
+  // ManualDWARFIndex).
   //
-  // Currently, OxCaml emits both:
-  // - DW_AT_name: mangled symbol (e.g., "camlModule__function_1_2_code")
-  // - DW_AT_linkage_name: OCaml name (e.g., "Module.function")
-  //
-  // If OxCaml stopped emitting DW_AT_linkage_name, we would implement the
-  // demangling logic here. We would also need to update ParseFunctionFromDWARF.
+  // The flat mangling scheme emits the source-level name directly in
+  // DW_AT_name (e.g. "Module.function") alongside the mangled
+  // DW_AT_linkage_name, so we use DW_AT_name as-is. The structured scheme emits
+  // only DW_AT_linkage_name (e.g. "_CamlU6ModuleF8function"), so we demangle it
+  // to recover the source-level name.
+  if (const char *name = die.GetName(); name && strlen(name) > 0)
+    return ConstString(name);
 
-  return ConstString(); // Currently returns empty as linkage names are provided
+  if (const char *linkage =
+          die.GetMangledName(/*substitute_name_allowed=*/false);
+      linkage && strlen(linkage) > 0) {
+    if (char *demangled = llvm::oxcamlDemangle(linkage)) {
+      ConstString result(demangled);
+      std::free(demangled);
+      return result;
+    }
+  }
+  return ConstString();
 }
 
 Function *DWARFASTParserOxCaml::ParseFunctionFromDWARF(
@@ -365,16 +378,15 @@ Function *DWARFASTParserOxCaml::ParseFunctionFromDWARF(
            "ParseFunctionFromDWARF: DIE 0x{0:x16} name=\"{1}\" mangled=\"{2}\"",
            die.GetID(), name ? name : "<null>", mangled ? mangled : "<null>");
 
-  // DW_AT_linkage_name is the mangled OCaml symbol; lldb now demangles it
-  // (Mangled::GetManglingScheme recognises the OCaml schemes), so a single
-  // SetValue routes it through the standard demangling path and GetName()
-  // returns the source-level name. Fall back to DW_AT_name if there is no
-  // linkage name.
+  // Record DW_AT_name (the source-level name, e.g. "Module.function") as the
+  // demangled name and DW_AT_linkage_name as the mangled name. The flat scheme
+  // emits both; the structured scheme emits only the linkage name, which the
+  // OxCaml demangler turns into the source-level name on demand.
   Mangled func_name;
+  if (name && strlen(name) > 0)
+    func_name.SetDemangledName(ConstString(name));
   if (mangled && strlen(mangled) > 0)
-    func_name.SetValue(ConstString(mangled));
-  else if (name && strlen(name) > 0)
-    func_name.SetValue(ConstString(name));
+    func_name.SetMangledName(ConstString(mangled));
   if (!func_name)
     return nullptr; // Must have a name
 

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserOxCaml.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserOxCaml.cpp
@@ -365,19 +365,16 @@ Function *DWARFASTParserOxCaml::ParseFunctionFromDWARF(
            "ParseFunctionFromDWARF: DIE 0x{0:x16} name=\"{1}\" mangled=\"{2}\"",
            die.GetID(), name ? name : "<null>", mangled ? mangled : "<null>");
 
-  // For OCaml, DW_AT_name is the source-level name (e.g., "Module.function")
-  // and DW_AT_linkage_name is the mangled assembly symbol (e.g.,
-  // "camlModule__function_1_2_code"). Mangled::SetValue would auto-detect via
-  // GetManglingScheme(), which doesn't recognize OCaml mangling, so we set
-  // both fields explicitly.
-  // TODO(oxcaml): once lldb has an OCaml demangler registered with
-  // Mangled::GetManglingScheme(), revert this to a single SetValue(mangled)
-  // call so demangling happens lazily through the standard path.
+  // DW_AT_linkage_name is the mangled OCaml symbol; lldb now demangles it
+  // (Mangled::GetManglingScheme recognises the OCaml schemes), so a single
+  // SetValue routes it through the standard demangling path and GetName()
+  // returns the source-level name. Fall back to DW_AT_name if there is no
+  // linkage name.
   Mangled func_name;
-  if (name && strlen(name) > 0)
-    func_name.SetDemangledName(ConstString(name));
   if (mangled && strlen(mangled) > 0)
-    func_name.SetMangledName(ConstString(mangled));
+    func_name.SetValue(ConstString(mangled));
+  else if (name && strlen(name) > 0)
+    func_name.SetValue(ConstString(name));
   if (!func_name)
     return nullptr; // Must have a name
 

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFIndex.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFIndex.cpp
@@ -30,9 +30,21 @@ bool DWARFIndex::ProcessFunctionDIE(
   llvm::StringRef name = lookup_info.GetLookupName().GetStringRef();
   FunctionNameType name_type_mask = lookup_info.GetNameTypeMask();
 
+  // For OCaml, name-based lookups compare against the source-level name
+  // (DW_AT_name, or the demangled DW_AT_linkage_name for the structured
+  // scheme) that users type, not the mangled linkage name that
+  // die.GetMangledName() returns.
+  const bool is_ocaml =
+      SymbolFileDWARF::GetLanguage(*die.GetCU()) == eLanguageTypeOCaml;
+  ConstString ocaml_source_name;
+  if (is_ocaml)
+    ocaml_source_name = die.GetDWARF()->ConstructFunctionDemangledName(die);
+
   if (!(name_type_mask & eFunctionNameTypeFull)) {
     ConstString name_to_match_against;
-    if (const char *mangled_die_name = die.GetMangledName()) {
+    if (is_ocaml) {
+      name_to_match_against = ocaml_source_name;
+    } else if (const char *mangled_die_name = die.GetMangledName()) {
       name_to_match_against = ConstString(mangled_die_name);
     } else {
       SymbolFileDWARF *symbols = die.GetDWARF();
@@ -58,8 +70,11 @@ bool DWARFIndex::ProcessFunctionDIE(
   if (!SymbolFileDWARF::DIEInDeclContext(parent_decl_ctx, die))
     return true;
 
-  // In case of a full match, we just insert everything we find.
-  const char *full_match_candidate = die.GetMangledName();
+  // In case of a full match, we just insert everything we find. For OCaml,
+  // match the user's input against the source-level name rather than the
+  // mangled linkage name.
+  const char *full_match_candidate =
+      is_ocaml ? ocaml_source_name.AsCString() : die.GetMangledName();
   if (name_type_mask & eFunctionNameTypeFull && full_match_candidate &&
       llvm::StringRef(full_match_candidate) == name)
     return callback(die);

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFIndex.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFIndex.cpp
@@ -30,23 +30,9 @@ bool DWARFIndex::ProcessFunctionDIE(
   llvm::StringRef name = lookup_info.GetLookupName().GetStringRef();
   FunctionNameType name_type_mask = lookup_info.GetNameTypeMask();
 
-  // For OCaml, DW_AT_linkage_name is the mangled assembly symbol and
-  // DW_AT_name is the source-level name users actually type. lldb has no
-  // OCaml demangler, so when comparing a DIE against user-supplied names we
-  // need the source name; the standard die.GetMangledName() (= linkage name)
-  // would never match.
-  // TODO(oxcaml): remove these OCaml carve-outs once lldb can demangle OCaml
-  // linkage names; die.GetMangledName() will then yield a string that the
-  // standard match logic can handle.
-  const bool is_ocaml =
-      SymbolFileDWARF::GetLanguage(*die.GetCU()) == eLanguageTypeOCaml;
-
   if (!(name_type_mask & eFunctionNameTypeFull)) {
     ConstString name_to_match_against;
-    if (is_ocaml) {
-      if (const char *die_name = die.GetName())
-        name_to_match_against = ConstString(die_name);
-    } else if (const char *mangled_die_name = die.GetMangledName()) {
+    if (const char *mangled_die_name = die.GetMangledName()) {
       name_to_match_against = ConstString(mangled_die_name);
     } else {
       SymbolFileDWARF *symbols = die.GetDWARF();
@@ -73,8 +59,7 @@ bool DWARFIndex::ProcessFunctionDIE(
     return true;
 
   // In case of a full match, we just insert everything we find.
-  const char *full_match_candidate =
-      is_ocaml ? die.GetName() : die.GetMangledName();
+  const char *full_match_candidate = die.GetMangledName();
   if (name_type_mask & eFunctionNameTypeFull && full_match_candidate &&
       llvm::StringRef(full_match_candidate) == name)
     return callback(die);

--- a/lldb/source/Plugins/SymbolFile/DWARF/ManualDWARFIndex.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/ManualDWARFIndex.cpp
@@ -335,17 +335,7 @@ void ManualDWARFIndex::IndexUnitImpl(DWARFUnit &unit,
           else
             set.function_basenames.Insert(ConstString(name), ref);
 
-          // For OCaml, DW_AT_name is the user-facing source name (e.g.
-          // "Module.function") and DW_AT_linkage_name is the mangled assembly
-          // symbol. lldb has no OCaml demangler, so the standard
-          // function_fullnames entry built from DW_AT_linkage_name below is
-          // not what users will type when setting a breakpoint. Index the
-          // source name as a full name too so that name-based lookups (which
-          // default to eFunctionNameTypeFull) hit it.
-          // TODO(oxcaml): remove the OCaml carve-out once lldb can demangle
-          // OCaml linkage names; the default branch will then suffice.
-          if (!is_method && !is_objc_method &&
-              (!mangled_cstr || cu_language == eLanguageTypeOCaml))
+          if (!is_method && !is_objc_method && !mangled_cstr)
             set.function_fullnames.Insert(ConstString(name), ref);
         }
         if (mangled_cstr) {

--- a/lldb/source/Plugins/SymbolFile/DWARF/ManualDWARFIndex.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/ManualDWARFIndex.cpp
@@ -21,9 +21,11 @@
 #include "lldb/Utility/DataExtractor.h"
 #include "lldb/Utility/Stream.h"
 #include "lldb/Utility/Timer.h"
+#include "llvm/Demangle/Demangle.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/ThreadPool.h"
 #include <atomic>
+#include <cstdlib>
 #include <optional>
 
 using namespace lldb_private;
@@ -299,6 +301,31 @@ void ManualDWARFIndex::IndexUnitImpl(DWARFUnit &unit,
     case DW_TAG_inlined_subroutine:
     case DW_TAG_subprogram:
       if (has_address) {
+        if (cu_language == eLanguageTypeOCaml) {
+          // For OCaml, index the source-level name so name-based lookups (which
+          // default to eFunctionNameTypeFull) resolve `break Module.function`.
+          // The flat scheme provides the source name in DW_AT_name; the
+          // structured scheme provides only DW_AT_linkage_name, which we
+          // demangle here. Keep this in sync with
+          // DWARFASTParserOxCaml::ConstructDemangledNameFromDWARF.
+          ConstString source_name;
+          if (name && name[0] != '\0') {
+            source_name = ConstString(name);
+          } else if (mangled_cstr && mangled_cstr[0] != '\0') {
+            if (char *demangled = llvm::oxcamlDemangle(mangled_cstr)) {
+              source_name = ConstString(demangled);
+              std::free(demangled);
+            }
+          }
+          if (source_name) {
+            set.function_basenames.Insert(source_name, ref);
+            set.function_fullnames.Insert(source_name, ref);
+          }
+          // Also index the mangled symbol so raw-symbol lookups still work.
+          if (mangled_cstr && mangled_cstr[0] != '\0')
+            set.function_fullnames.Insert(ConstString(mangled_cstr), ref);
+          break;
+        }
         if (name) {
           bool is_objc_method = false;
           if (cu_language == eLanguageTypeObjC ||
@@ -335,7 +362,7 @@ void ManualDWARFIndex::IndexUnitImpl(DWARFUnit &unit,
           else
             set.function_basenames.Insert(ConstString(name), ref);
 
-          if (!is_method && !is_objc_method && !mangled_cstr)
+          if (!is_method && !mangled_cstr && !is_objc_method)
             set.function_fullnames.Insert(ConstString(name), ref);
         }
         if (mangled_cstr) {

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -1376,42 +1376,11 @@ size_t SymbolFileDWARF::ParseBlocksRecursive(CompileUnit &comp_unit,
                   call_file.value_or(0)),
               call_line.value_or(0), call_column.value_or(0));
 
-        // For OCaml, the default char-pointer overload would feed
-        // mangled_name through Mangled::SetValue, which doesn't recognise
-        // OCaml mangling and would route the linkage name into m_demangled.
-        // Backtraces (e.g. "[inlined] camlHello__concat_1_4_code") would then
-        // show the mangled symbol instead of the source name. Build the
-        // Mangled explicitly so both slots are populated correctly.
-        // TODO(oxcaml): drop this carve-out once lldb has an OCaml demangler
-        // registered with Mangled::GetManglingScheme(); the default branch
-        // will then suffice.
-        if (GetLanguage(*die.GetCU()) == eLanguageTypeOCaml) {
-          Mangled inlined_mangled;
-          if (name && name[0] != '\0')
-            inlined_mangled.SetDemangledName(ConstString(name));
-          if (mangled_name && mangled_name[0] != '\0')
-            inlined_mangled.SetMangledName(ConstString(mangled_name));
-          block->SetInlinedFunctionInfo(ConstString(name), inlined_mangled,
-                                        decl_up.get(), call_up.get());
-        } else {
-          block->SetInlinedFunctionInfo(name, mangled_name, decl_up.get(),
-                                        call_up.get());
-
-        /* FIXME(oxcaml) Should it be this instead?
-          // If mangled_name is NULL but name is mangled (e.g., OxCaml symbols),
-          // swap them so the Mangled class can handle demangling correctly
-          const char *use_name = name;
-          const char *use_mangled = mangled_name;
-          if (mangled_name == nullptr && name != nullptr &&
-              Mangled::GetManglingScheme(name) != Mangled::eManglingSchemeNone) {
-            use_mangled = name;
-            use_name = nullptr;
-          }
-
-          block->SetInlinedFunctionInfo(use_name, use_mangled, decl_up.get(),
-                                        call_up.get());
-        */
-        }
+        // For OCaml, mangled_name is the mangled assembly symbol; lldb now
+        // demangles it through Mangled::GetManglingScheme(), so the default
+        // overload yields the source-level name in inlined backtraces.
+        block->SetInlinedFunctionInfo(name, mangled_name, decl_up.get(),
+                                      call_up.get());
       }
 
       ++blocks_added;

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -1396,6 +1396,21 @@ size_t SymbolFileDWARF::ParseBlocksRecursive(CompileUnit &comp_unit,
         } else {
           block->SetInlinedFunctionInfo(name, mangled_name, decl_up.get(),
                                         call_up.get());
+
+        /* FIXME(oxcaml) Should it be this instead?
+          // If mangled_name is NULL but name is mangled (e.g., OxCaml symbols),
+          // swap them so the Mangled class can handle demangling correctly
+          const char *use_name = name;
+          const char *use_mangled = mangled_name;
+          if (mangled_name == nullptr && name != nullptr &&
+              Mangled::GetManglingScheme(name) != Mangled::eManglingSchemeNone) {
+            use_mangled = name;
+            use_name = nullptr;
+          }
+
+          block->SetInlinedFunctionInfo(use_name, use_mangled, decl_up.get(),
+                                        call_up.get());
+        */
         }
       }
 

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -1376,11 +1376,22 @@ size_t SymbolFileDWARF::ParseBlocksRecursive(CompileUnit &comp_unit,
                   call_file.value_or(0)),
               call_line.value_or(0), call_column.value_or(0));
 
-        // For OCaml, mangled_name is the mangled assembly symbol; lldb now
-        // demangles it through Mangled::GetManglingScheme(), so the default
-        // overload yields the source-level name in inlined backtraces.
-        block->SetInlinedFunctionInfo(name, mangled_name, decl_up.get(),
-                                      call_up.get());
+        // For OCaml, prefer DW_AT_name (the source-level name) when present and
+        // otherwise demangle the DW_AT_linkage_name (which for the structured
+        // scheme reconstructs the source name). Build the Mangled explicitly
+        // so both slots are populated correctly.
+        if (GetLanguage(*die.GetCU()) == eLanguageTypeOCaml) {
+          Mangled inlined_mangled;
+          if (name && strlen(name) > 0)
+            inlined_mangled.SetDemangledName(ConstString(name));
+          if (mangled_name && strlen(mangled_name) > 0)
+            inlined_mangled.SetMangledName(ConstString(mangled_name));
+          block->SetInlinedFunctionInfo(ConstString(name), inlined_mangled,
+                                        decl_up.get(), call_up.get());
+        } else {
+          block->SetInlinedFunctionInfo(name, mangled_name, decl_up.get(),
+                                        call_up.get());
+        }
       }
 
       ++blocks_added;

--- a/lldb/source/Symbol/Symtab.cpp
+++ b/lldb/source/Symbol/Symtab.cpp
@@ -266,6 +266,7 @@ static bool lldb_skip_name(llvm::StringRef mangled,
 
   // No filters for this scheme yet. Include all names in indexing.
   case Mangled::eManglingSchemeMSVC:
+  case Mangled::eManglingSchemeOxCaml:
   case Mangled::eManglingSchemeRustV0:
   case Mangled::eManglingSchemeD:
   case Mangled::eManglingSchemeSwift:

--- a/llvm/include/llvm/Demangle/Demangle.h
+++ b/llvm/include/llvm/Demangle/Demangle.h
@@ -58,9 +58,10 @@ char *microsoftDemangle(std::string_view mangled_name, size_t *n_read,
 std::optional<size_t>
 getArm64ECInsertionPointInMangledName(std::string_view MangledName);
 
-// Demangles an OxCaml mangled symbol (structured "_Caml" scheme or the legacy
-// flat "caml"/"_caml" schemes). The trailing (non-deterministic) compiler
-// stamp is stripped from the result.
+// Demangles an OxCaml mangled symbol (structured "_Caml"/"__Caml" scheme or the
+// legacy flat "caml"/"_caml" scheme). The trailing (non-deterministic) compiler
+// stamp is stripped from the result. Returns nullptr if MangledName is not a
+// valid OxCaml mangled name.
 char *oxcamlDemangle(std::string_view MangledName);
 
 // Returns true if MangledName uses a recognised OxCaml mangling scheme.

--- a/llvm/include/llvm/Demangle/Demangle.h
+++ b/llvm/include/llvm/Demangle/Demangle.h
@@ -58,8 +58,16 @@ char *microsoftDemangle(std::string_view mangled_name, size_t *n_read,
 std::optional<size_t>
 getArm64ECInsertionPointInMangledName(std::string_view MangledName);
 
-// Demangles an OxCaml mangled symbol
+// Demangles an OxCaml mangled symbol (structured "_Caml" scheme or the legacy
+// flat "caml"/"_caml" schemes).
 char *oxcamlDemangle(std::string_view MangledName);
+
+// Returns true if MangledName uses a recognised OxCaml mangling scheme.
+bool isOxCamlMangledName(std::string_view MangledName);
+
+// Like oxcamlDemangle, but strips the trailing (non-deterministic) compiler
+// stamp from the result for display purposes.
+char *oxcamlDemangleNoStamp(std::string_view MangledName);
 
 // Demangles a Rust v0 mangled symbol.
 char *rustDemangle(std::string_view MangledName);

--- a/llvm/include/llvm/Demangle/Demangle.h
+++ b/llvm/include/llvm/Demangle/Demangle.h
@@ -58,6 +58,9 @@ char *microsoftDemangle(std::string_view mangled_name, size_t *n_read,
 std::optional<size_t>
 getArm64ECInsertionPointInMangledName(std::string_view MangledName);
 
+// Demangles an OxCaml mangled symbol
+char *oxcamlDemangle(std::string_view MangledName);
+
 // Demangles a Rust v0 mangled symbol.
 char *rustDemangle(std::string_view MangledName);
 

--- a/llvm/include/llvm/Demangle/Demangle.h
+++ b/llvm/include/llvm/Demangle/Demangle.h
@@ -65,6 +65,12 @@ getArm64ECInsertionPointInMangledName(std::string_view MangledName);
 char *oxcamlDemangle(std::string_view MangledName);
 
 // Returns true if MangledName uses a recognised OxCaml mangling scheme.
+//
+// This is a loose candidate filter based on the scheme prefix, not a guarantee
+// that the name demangles: some names it accepts (e.g. "_Caml" with an empty
+// path) are still rejected by oxcamlDemangle, just as the other schemes'
+// prefix-based predicates behave. Callers must therefore handle a nullptr
+// result from oxcamlDemangle even when this returns true.
 bool isOxCamlMangledName(std::string_view MangledName);
 
 // Demangles a Rust v0 mangled symbol.

--- a/llvm/include/llvm/Demangle/Demangle.h
+++ b/llvm/include/llvm/Demangle/Demangle.h
@@ -59,15 +59,12 @@ std::optional<size_t>
 getArm64ECInsertionPointInMangledName(std::string_view MangledName);
 
 // Demangles an OxCaml mangled symbol (structured "_Caml" scheme or the legacy
-// flat "caml"/"_caml" schemes).
+// flat "caml"/"_caml" schemes). The trailing (non-deterministic) compiler
+// stamp is stripped from the result.
 char *oxcamlDemangle(std::string_view MangledName);
 
 // Returns true if MangledName uses a recognised OxCaml mangling scheme.
 bool isOxCamlMangledName(std::string_view MangledName);
-
-// Like oxcamlDemangle, but strips the trailing (non-deterministic) compiler
-// stamp from the result for display purposes.
-char *oxcamlDemangleNoStamp(std::string_view MangledName);
 
 // Demangles a Rust v0 mangled symbol.
 char *rustDemangle(std::string_view MangledName);

--- a/llvm/lib/Demangle/CMakeLists.txt
+++ b/llvm/lib/Demangle/CMakeLists.txt
@@ -3,6 +3,7 @@ add_llvm_component_library(LLVMDemangle
   ItaniumDemangle.cpp
   MicrosoftDemangle.cpp
   MicrosoftDemangleNodes.cpp
+  OxCamlDemangle.cpp
   RustDemangle.cpp
   DLangDemangle.cpp
 

--- a/llvm/lib/Demangle/Demangle.cpp
+++ b/llvm/lib/Demangle/Demangle.cpp
@@ -44,7 +44,7 @@ static bool isItaniumEncoding(std::string_view S) {
 }
 
 static bool isOxCamlEncoding(std::string_view S) {
-  return starts_with(S, "_Caml");
+  return llvm::isOxCamlMangledName(S);
 }
 
 static bool isRustEncoding(std::string_view S) { return starts_with(S, "_R"); }

--- a/llvm/lib/Demangle/Demangle.cpp
+++ b/llvm/lib/Demangle/Demangle.cpp
@@ -43,6 +43,10 @@ static bool isItaniumEncoding(std::string_view S) {
   return Pos > 0 && Pos <= 4 && S[Pos] == 'Z';
 }
 
+static bool isOxCamlEncoding(std::string_view S) {
+  return starts_with(S, "_Caml");
+}
+
 static bool isRustEncoding(std::string_view S) { return starts_with(S, "_R"); }
 
 static bool isDLangEncoding(std::string_view S) { return starts_with(S, "_D"); }
@@ -64,6 +68,8 @@ bool llvm::nonMicrosoftDemangle(std::string_view MangledName,
     Demangled = rustDemangle(MangledName);
   else if (isDLangEncoding(MangledName))
     Demangled = dlangDemangle(MangledName);
+  else if (isOxCamlEncoding(MangledName))
+    Demangled = oxcamlDemangle(MangledName);
 
   if (!Demangled)
     return false;

--- a/llvm/lib/Demangle/OxCamlDemangle.cpp
+++ b/llvm/lib/Demangle/OxCamlDemangle.cpp
@@ -20,29 +20,39 @@
 using llvm::itanium_demangle::starts_with;
 using llvm::itanium_demangle::OutputBuffer;
 
-#define ERROR (~((unsigned)0))
+// Sentinel returned by the Consume* helpers when no digits could be parsed, or
+// the value would overflow. All callers must treat it as a parse failure.
+static constexpr unsigned kParseError = ~0u;
 
-static unsigned ConsumeUnsignedDecimal(std::string_view& sv) {
+static unsigned ConsumeUnsignedDecimal(std::string_view &sv) {
   unsigned res = 0, i = 0;
-  while(sv[i] >= '0' && sv[i] <= '9') {
-    res = res * 10 + (sv[i] - '0');
+  while (i < sv.size() && sv[i] >= '0' && sv[i] <= '9') {
+    unsigned digit = (unsigned)(sv[i] - '0');
+    // Reject values that would overflow, mirroring the compiler's
+    // int_of_string_opt, rather than wrapping silently.
+    if (res > (kParseError - digit) / 10)
+      return kParseError;
+    res = res * 10 + digit;
     i++;
   }
   sv.remove_prefix(i);
-  if(i == 0)
-    return ERROR;
+  if (i == 0)
+    return kParseError;
   return res;
 }
 
-static unsigned ConsumeUnsigned26(std::string_view& sv) {
+static unsigned ConsumeUnsigned26(std::string_view &sv) {
   unsigned res = 0, i = 0;
-  while(sv[i] >= 'A' && sv[i] <= 'Z') {
-    res = res * 26 + (sv[i] - 'A');
+  while (i < sv.size() && sv[i] >= 'A' && sv[i] <= 'Z') {
+    unsigned digit = (unsigned)(sv[i] - 'A');
+    if (res > (kParseError - digit) / 26)
+      return kParseError;
+    res = res * 26 + digit;
     i++;
   }
   sv.remove_prefix(i);
-  if(i == 0)
-    return ERROR;
+  if (i == 0)
+    return kParseError;
   return res;
 }
 
@@ -63,7 +73,7 @@ static unsigned lowerhex(char c) {
 // Returns true on success, false on error
 static bool DecodeEscaped(std::string_view& Mangled, OutputBuffer& Demangled) {
   unsigned len = ConsumeUnsignedDecimal(Mangled);
-  if(len == ERROR || len <= 0 || len > Mangled.size())
+  if(len == kParseError || len <= 0 || len > Mangled.size())
     return false;
 
   size_t split = Mangled.find('_');
@@ -75,7 +85,7 @@ static bool DecodeEscaped(std::string_view& Mangled, OutputBuffer& Demangled) {
 
   while(!coded.empty()) {
     unsigned chunklen = ConsumeUnsigned26(coded);
-    if(chunklen == ERROR || chunklen > raw.size())
+    if(chunklen == kParseError || chunklen > raw.size())
       return false;
     Demangled << raw.substr(0, chunklen);
     raw.remove_prefix(chunklen);
@@ -108,7 +118,7 @@ static bool DecodeIdentifier(std::string_view& Mangled, OutputBuffer& Demangled)
   } else {
     // Plain identifier with length prefix
     unsigned len = ConsumeUnsignedDecimal(Mangled);
-    if(len == ERROR || len <= 0 || len > Mangled.size())
+    if(len == kParseError || len <= 0 || len > Mangled.size())
       return false;
     Demangled << Mangled.substr(0, len);
     Mangled.remove_prefix(len);
@@ -158,46 +168,72 @@ static bool DecodeAnonymousLocation(std::string_view& Mangled, OutputBuffer& Dem
     }
   }
 
-  // Output in format type(filename:line:col)
-  if(underscore_count >= 2) {
-    switch(typ) {
-      case 'S':
-        Demangled << "mod";
-        break;
-      case 'L':
-        Demangled << "fn";
-        break;
-      case 'P':
-        Demangled << "partial";
-        break;
-      default:
-        assert(0);
-    }
-    Demangled << '(';
-    for(size_t j = 0; j < first_underscore; j++)
-      Demangled << buf[j];
-    Demangled << ':';
-    for(size_t j = first_underscore + 1; j < second_underscore; j++)
-      Demangled << buf[j];
-    Demangled << ':';
-    for(size_t j = second_underscore + 1; j < temp_len; j++)
-      Demangled << buf[j];
-    Demangled << ')';
-  } else {
-    // Fallback: just output the identifier as-is
-    for(size_t j = 0; j < temp_len; j++)
-      Demangled << buf[j];
+  // The compiler parser (structured_mangling.ml, parse_location) requires the
+  // exact "filename_line_col" shape with numeric line and column fields, and
+  // rejects the whole symbol otherwise. Mirror that: reject here so the symbol
+  // is passed through unchanged rather than emitting a malformed location.
+  auto all_digits = [&](size_t begin, size_t end) {
+    if(begin >= end)
+      return false;
+    for(size_t j = begin; j < end; j++)
+      if(buf[j] < '0' || buf[j] > '9')
+        return false;
+    return true;
+  };
+  if(underscore_count < 2 ||
+     !all_digits(first_underscore + 1, second_underscore) ||
+     !all_digits(second_underscore + 1, temp_len)) {
+    std::free(buf);
+    return false;
   }
+
+  // Output in format type(filename:line:col)
+  switch(typ) {
+    case 'S':
+      Demangled << "mod";
+      break;
+    case 'L':
+      Demangled << "fn";
+      break;
+    case 'P':
+      Demangled << "partial";
+      break;
+    default:
+      assert(0);
+  }
+  Demangled << '(';
+  for(size_t j = 0; j < first_underscore; j++)
+    Demangled << buf[j];
+  Demangled << ':';
+  for(size_t j = first_underscore + 1; j < second_underscore; j++)
+    Demangled << buf[j];
+  Demangled << ':';
+  for(size_t j = second_underscore + 1; j < temp_len; j++)
+    Demangled << buf[j];
+  Demangled << ')';
 
   std::free(buf);
   return true;
 }
 
-// Demangle a symbol in the structured scheme (prefix "_Caml").
+// Length of the structured-scheme prefix at the start of Mangled, or 0 if there
+// is none. The bare prefix is "_Caml"; the macOS assembler prepends a leading
+// underscore, giving "__Caml". Both are accepted, matching the compiler parser
+// (structured_mangling.ml) and mirroring the flat path's "_caml" handling.
+static size_t MatchedStructuredPrefixLen(std::string_view Mangled) {
+  if(starts_with(Mangled, "__Caml"))
+    return 6;
+  if(starts_with(Mangled, "_Caml"))
+    return 5;
+  return 0;
+}
+
+// Demangle a symbol in the structured scheme (prefix "_Caml"/"__Caml").
 static char *demangleStructured(std::string_view Mangled) {
-  if(!starts_with(Mangled, "_Caml"))
+  size_t prefix_len = MatchedStructuredPrefixLen(Mangled);
+  if(prefix_len == 0)
     return nullptr;
-  Mangled.remove_prefix(5);
+  Mangled.remove_prefix(prefix_len);
 
   // Allocate the buffer at a reasonable size, as OutputBuffer allocates 992
   // bytes when starting from an empty buffer
@@ -207,10 +243,11 @@ static char *demangleStructured(std::string_view Mangled) {
     std::terminate();
   OutputBuffer Demangled(DemangledBuffer, Mangled.size());
 
-#define ENDONERROR() do {           \
-  std::free(Demangled.getBuffer()); \
-  return nullptr;                   \
-} while(0)
+  // Free the output buffer and report failure; used on every error path below.
+  auto fail = [&]() -> char * {
+    std::free(Demangled.getBuffer());
+    return nullptr;
+  };
 
   // Parse path items
   while(!Mangled.empty()) {
@@ -230,7 +267,7 @@ static char *demangleStructured(std::string_view Mangled) {
                   Demangled << '.';
               Mangled.remove_prefix(1);
               if(!DecodeIdentifier(Mangled, Demangled))
-                  ENDONERROR();
+                  return fail();
               break;
 
           case 'S':  // anonymous Struct
@@ -241,7 +278,7 @@ static char *demangleStructured(std::string_view Mangled) {
               char typ = Mangled[0];
               Mangled.remove_prefix(1);
               if(!DecodeAnonymousLocation(Mangled, Demangled, typ))
-                  ENDONERROR();
+                  return fail();
               break;
           }
           case 'I':  // Inline marker (specialization)
@@ -255,20 +292,21 @@ static char *demangleStructured(std::string_view Mangled) {
               break;
 
           default:
-              ENDONERROR();
+              return fail();
       }
   }
 
   // A valid symbol must contain at least one path item; reject names like
   // "_Caml" or "_Caml_123" that decoded to nothing.
   if(Demangled.getCurrentPosition() == 0)
-      ENDONERROR();
+      return fail();
 
-  // Append the trailing suffix (compiler-appended unique ids such as "_5_code")
-  // verbatim. They keep otherwise-identical symbols distinct, so dropping them
-  // would risk name clashes.
-  Demangled << Mangled;
-
+  // Anything left in Mangled is the compiler-appended suffix (unique ids such as
+  // "_5_code") that begins at the terminating underscore. Because the path was
+  // decoded from exact length-prefixed identifiers, this boundary is precise, so
+  // we drop the suffix here rather than re-deriving it heuristically over the
+  // whole demangled string (which would also strip digits from real identifiers
+  // such as "add_2").
   Demangled << '\0';
 
   return Demangled.getBuffer();
@@ -277,12 +315,10 @@ static char *demangleStructured(std::string_view Mangled) {
 // ===========================================================================
 // Flat scheme (legacy "caml"/"_caml" prefixes)
 //
-// Ports the flat0 (OCaml <= 5.2) and flat1 (OCaml >= 5.3) demanglers from the
-// ocamlfilt reference tool. flat0 uses "__" as the module separator and "$xx"
-// hex escapes. flat1 additionally supports the macOS assembler flavour, which
-// uses "$" as the separator and "$$xx"/"$$$xx" escapes; the flavour is
-// auto-detected per symbol. As with the structured scheme, the trailing
-// compiler suffix (e.g. "_42") is preserved verbatim.
+// Ports the flat0 (OCaml <= 5.2) demangler from the ocamlfilt reference tool:
+// "__" is the module separator and "$xx" a hex escape. The trailing compiler
+// stamp is stripped heuristically (flat names are not length-delimited, so the
+// boundary cannot be known exactly as it can for the structured scheme).
 // ===========================================================================
 
 static bool IsUpperAZ(char c) { return c >= 'A' && c <= 'Z'; }
@@ -310,35 +346,6 @@ static size_t MatchedFlatPrefixLen(std::string_view Mangled) {
   if(Mangled.size() > 4 && starts_with(Mangled, "caml") && IsUpperAZ(Mangled[4]))
     return 4;
   return 0;
-}
-
-enum class FlatStyle { Linux, Macos };
-
-// flat1 emits one of two flavours per binary. A bare '.' or "__" is a positive
-// Linux marker; "$$" or a '$' not followed by two hex digits is a positive
-// macOS marker. A '$' followed by two hex digits is ambiguous in isolation, so
-// if no Linux marker appears anywhere the only coherent reading is macOS.
-static FlatStyle DetectFlatStyle(std::string_view S, size_t PrefixLen) {
-  size_t len = S.size();
-  bool saw_dollar_hex_pair = false;
-  for(size_t i = PrefixLen; i < len;) {
-    if(S[i] == '.')
-      return FlatStyle::Linux;
-    if(S[i] == '_' && i + 1 < len && S[i + 1] == '_')
-      return FlatStyle::Linux;
-    if(S[i] == '$') {
-      if(i + 1 < len && S[i + 1] == '$')
-        return FlatStyle::Macos;
-      if(i + 2 < len && IsFlatXDigit(S[i + 1]) && IsFlatXDigit(S[i + 2])) {
-        saw_dollar_hex_pair = true;
-        i += 3;
-        continue;
-      }
-      return FlatStyle::Macos;
-    }
-    i++;
-  }
-  return saw_dollar_hex_pair ? FlatStyle::Macos : FlatStyle::Linux;
 }
 
 // flat0 (OCaml <= 5.2): "__" -> '.', "$xx" -> hex char, else literal. Returns a
@@ -379,84 +386,9 @@ static char *demangleFlat0(std::string_view S, size_t PrefixLen) {
   return Out;
 }
 
-// flat1 (OCaml >= 5.3): Linux flavour matches flat0; the macOS flavour uses '$'
-// as the separator with "$$xx" / "$$$xx" escapes. Returns a malloc'd C string.
-static char *demangleFlat1(std::string_view S, size_t PrefixLen) {
-  size_t len = S.size();
-  FlatStyle style = DetectFlatStyle(S, PrefixLen);
-  char *Out = static_cast<char *>(std::malloc(len + 1));
-  if(Out == nullptr)
-    std::terminate();
-
-  size_t j = 0;
-  for(size_t i = PrefixLen; i < len;) {
-    if(style == FlatStyle::Macos) {
-      if(S[i] != '$') {
-        Out[j++] = S[i++];
-        continue;
-      }
-      if(i + 4 < len && S[i + 1] == '$' && S[i + 2] == '$' &&
-         IsFlatXDigit(S[i + 3]) && IsFlatXDigit(S[i + 4])) {
-        // "$$$xx" -> separator + hex char
-        Out[j++] = '.';
-        Out[j++] = (char)((FlatHex(S[i + 3]) << 4) | FlatHex(S[i + 4]));
-        i += 5;
-        continue;
-      }
-      if(i + 3 < len && S[i + 1] == '$' && IsFlatXDigit(S[i + 2]) &&
-         IsFlatXDigit(S[i + 3])) {
-        // "$$xx" -> hex char
-        Out[j++] = (char)((FlatHex(S[i + 2]) << 4) | FlatHex(S[i + 3]));
-        i += 4;
-        continue;
-      }
-      // bare '$' -> separator
-      Out[j++] = '.';
-      i++;
-      continue;
-    }
-
-    // Linux flavour
-    if(S[i] == '$') {
-      if(i + 2 < len && IsFlatXDigit(S[i + 1]) && IsFlatXDigit(S[i + 2])) {
-        Out[j++] = (char)((FlatHex(S[i + 1]) << 4) | FlatHex(S[i + 2]));
-        i += 3;
-        continue;
-      }
-      Out[j++] = '$';
-      i++;
-      continue;
-    }
-    if(S[i] == '_' && i + 1 < len && S[i + 1] == '_') {
-      Out[j++] = '.';
-      i += 2;
-      continue;
-    }
-    Out[j++] = S[i++];
-  }
-  Out[j] = '\0';
-  return Out;
-}
-
 bool llvm::isOxCamlMangledName(std::string_view MangledName) {
-  return starts_with(MangledName, "_Caml") ||
+  return MatchedStructuredPrefixLen(MangledName) != 0 ||
          MatchedFlatPrefixLen(MangledName) != 0;
-}
-
-// Dispatch to the appropriate scheme, without post-processing.
-static char *demangleAnyScheme(std::string_view Mangled) {
-  if(starts_with(Mangled, "_Caml"))
-    return demangleStructured(Mangled);
-
-  if(size_t PrefixLen = MatchedFlatPrefixLen(Mangled)) {
-    // flat1 (>= 5.3) is a superset of flat0; only fall back to flat0 (<= 5.2)
-    // if flat1 rejects the symbol.
-    if(char *Result = demangleFlat1(Mangled, PrefixLen))
-      return Result;
-    return demangleFlat0(Mangled, PrefixLen);
-  }
-
-  return nullptr;
 }
 
 // Length of the demangled name S[0..len) with any trailing OCaml compiler stamp
@@ -495,16 +427,30 @@ static size_t lengthWithoutStamp(const char *S, size_t len) {
   return end;
 }
 
-char *llvm::oxcamlDemangle(std::string_view Mangled) {
-  char *Result = demangleAnyScheme(Mangled);
-  if(Result == nullptr)
-    return nullptr;
-
-  // Strip the trailing compiler stamp: it is a non-deterministic counter with
-  // no source meaning, so it is dropped from the demangled name.
+// Truncate Result in place at the end of its source-meaningful content, i.e.
+// drop the trailing compiler stamp. Used for the flat scheme only.
+static void stripTrailingStamp(char *Result) {
   size_t len = 0;
   while(Result[len] != '\0')
     len++;
   Result[lengthWithoutStamp(Result, len)] = '\0';
-  return Result;
+}
+
+char *llvm::oxcamlDemangle(std::string_view Mangled) {
+  // Structured scheme: the demangler knows the exact path/suffix boundary and
+  // drops the stamp itself, so its result needs no post-processing.
+  if(MatchedStructuredPrefixLen(Mangled))
+    return demangleStructured(Mangled);
+
+  // Flat scheme: there are no length delimiters, so the trailing compiler stamp
+  // can only be removed heuristically after demangling.
+  if(size_t PrefixLen = MatchedFlatPrefixLen(Mangled)) {
+    char *Result = demangleFlat0(Mangled, PrefixLen);
+    if(Result == nullptr)
+      return nullptr;
+    stripTrailingStamp(Result);
+    return Result;
+  }
+
+  return nullptr;
 }

--- a/llvm/lib/Demangle/OxCamlDemangle.cpp
+++ b/llvm/lib/Demangle/OxCamlDemangle.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <cassert>
+#include <cstring>
 #include <limits>
 #include <optional>
 #include <string_view>
@@ -129,23 +130,25 @@ static bool DecodeIdentifier(std::string_view& Mangled, OutputBuffer& Demangled)
   }
 }
 
+// True if buf[begin, end) is a non-empty run of decimal digits.
+static bool AllDigits(const char *buf, size_t begin, size_t end) {
+  if(begin >= end)
+    return false;
+  for(size_t j = begin; j < end; j++)
+    if(buf[j] < '0' || buf[j] > '9')
+      return false;
+  return true;
+}
+
 // Decode anonymous location (format: filename_line_col)
 // Anonymous functions, modules and partial functions are encoded as:
 //   type(filename:line:col)
 // where <type> can be fn, mod or partial
 // Returns true on success, false on error
 static bool DecodeAnonymousLocation(std::string_view& Mangled, OutputBuffer& Demangled, char typ) {
-  // Allocate temporary buffer based on remaining mangled string size
-  // The decoded identifier will be at most the size of the remaining mangled string
-  size_t buffer_size = Mangled.size();
-  if(buffer_size == 0)
-    return false;
-
-  char *temp_buf = static_cast<char *>(std::malloc(buffer_size));
-  if(temp_buf == nullptr)
-    std::terminate();
-
-  OutputBuffer TempDemangled(temp_buf, buffer_size);
+  // Decode the identifier into a scratch buffer first; once we know where its
+  // last two underscores are we re-emit it as type(filename:line:col).
+  OutputBuffer TempDemangled;
 
   if(!DecodeIdentifier(Mangled, TempDemangled)) {
     std::free(TempDemangled.getBuffer());
@@ -175,17 +178,9 @@ static bool DecodeAnonymousLocation(std::string_view& Mangled, OutputBuffer& Dem
   // exact "filename_line_col" shape with numeric line and column fields, and
   // rejects the whole symbol otherwise. Mirror that: reject here so the symbol
   // is passed through unchanged rather than emitting a malformed location.
-  auto all_digits = [&](size_t begin, size_t end) {
-    if(begin >= end)
-      return false;
-    for(size_t j = begin; j < end; j++)
-      if(buf[j] < '0' || buf[j] > '9')
-        return false;
-    return true;
-  };
   if(underscore_count < 2 ||
-     !all_digits(first_underscore + 1, second_underscore) ||
-     !all_digits(second_underscore + 1, temp_len)) {
+     !AllDigits(buf, first_underscore + 1, second_underscore) ||
+     !AllDigits(buf, second_underscore + 1, temp_len)) {
     std::free(buf);
     return false;
   }
@@ -238,15 +233,7 @@ static char *demangleStructured(std::string_view Mangled) {
     return nullptr;
   Mangled.remove_prefix(prefix_len);
 
-  // Allocate the buffer at a reasonable size, as OutputBuffer allocates 992
-  // bytes when starting from an empty buffer. Add one so the allocation is never
-  // zero (malloc(0) may return nullptr, which we treat as failure) for an empty
-  // path such as "_Caml"; OutputBuffer grows on demand if the path is longer.
-  size_t buffer_size = Mangled.size() + 1;
-  char *DemangledBuffer = static_cast<char *>(std::malloc(buffer_size));
-  if (DemangledBuffer == nullptr)
-    std::terminate();
-  OutputBuffer Demangled(DemangledBuffer, buffer_size);
+  OutputBuffer Demangled;
 
   // Free the output buffer and report failure; used on every error path below.
   auto fail = [&]() -> char * {
@@ -306,12 +293,11 @@ static char *demangleStructured(std::string_view Mangled) {
   if(Demangled.getCurrentPosition() == 0)
       return fail();
 
-  // Anything left in Mangled is the compiler-appended suffix (unique ids such as
-  // "_5_code") that begins at the terminating underscore. Because the path was
-  // decoded from exact length-prefixed identifiers, this boundary is precise, so
-  // we drop the suffix here rather than re-deriving it heuristically over the
-  // whole demangled string (which would also strip digits from real identifiers
-  // such as "add_2").
+  // Whatever remains in Mangled is the compiler-appended suffix (e.g.
+  // "_5_code"). The path was decoded from exact length-prefixed identifiers, so
+  // this boundary is precise: we drop the suffix simply by not appending it.
+  // (The flat scheme, lacking length prefixes, must instead strip the stamp
+  // heuristically; see stripTrailingStamp.)
   Demangled << '\0';
 
   return Demangled.getBuffer();
@@ -357,38 +343,35 @@ static size_t MatchedFlatPrefixLen(std::string_view Mangled) {
 // malloc'd C string.
 static char *demangleFlat0(std::string_view S, size_t PrefixLen) {
   size_t len = S.size();
-  char *Out = static_cast<char *>(std::malloc(len + 1));
-  if(Out == nullptr)
-    std::terminate();
+  OutputBuffer Demangled;
 
-  size_t j = 0;
   for(size_t i = PrefixLen; i < len;) {
     if(S[i] == '_') {
       if(i + 1 >= len)
         break; // dangling '_' -> stop
       if(S[i + 1] == '_') {
-        Out[j++] = '.';
+        Demangled << '.';
         i += 2;
         continue;
       }
-      Out[j++] = '_';
+      Demangled << '_';
       i++;
       continue;
     }
     if(S[i] == '$') {
       if(i + 2 < len && IsFlatXDigit(S[i + 1]) && IsFlatXDigit(S[i + 2])) {
-        Out[j++] = (char)((FlatHex(S[i + 1]) << 4) | FlatHex(S[i + 2]));
+        Demangled << (char)((FlatHex(S[i + 1]) << 4) | FlatHex(S[i + 2]));
         i += 3;
         continue;
       }
-      Out[j++] = '$'; // not a valid escape -> literal '$'
+      Demangled << '$'; // not a valid escape -> literal '$'
       i++;
       continue;
     }
-    Out[j++] = S[i++];
+    Demangled << S[i++];
   }
-  Out[j] = '\0';
-  return Out;
+  Demangled << '\0';
+  return Demangled.getBuffer();
 }
 
 bool llvm::isOxCamlMangledName(std::string_view MangledName) {
@@ -435,9 +418,7 @@ static size_t lengthWithoutStamp(const char *S, size_t len) {
 // Truncate Result in place at the end of its source-meaningful content, i.e.
 // drop the trailing compiler stamp. Used for the flat scheme only.
 static void stripTrailingStamp(char *Result) {
-  size_t len = 0;
-  while(Result[len] != '\0')
-    len++;
+  size_t len = std::strlen(Result);
   Result[lengthWithoutStamp(Result, len)] = '\0';
 }
 

--- a/llvm/lib/Demangle/OxCamlDemangle.cpp
+++ b/llvm/lib/Demangle/OxCamlDemangle.cpp
@@ -443,7 +443,8 @@ bool llvm::isOxCamlMangledName(std::string_view MangledName) {
          MatchedFlatPrefixLen(MangledName) != 0;
 }
 
-char *llvm::oxcamlDemangle(std::string_view Mangled) {
+// Dispatch to the appropriate scheme, without post-processing.
+static char *demangleAnyScheme(std::string_view Mangled) {
   if(starts_with(Mangled, "_Caml"))
     return demangleStructured(Mangled);
 
@@ -466,36 +467,41 @@ char *llvm::oxcamlDemangle(std::string_view Mangled) {
 // Source spans ("[...]"/"(...)") and operator/identifier characters are kept,
 // since they do not end in "_<digits>".
 static size_t lengthWithoutStamp(const char *S, size_t len) {
-  // Strip one trailing "_<digits>" group ending at End; return the new end, or
-  // End unchanged when there is no such group.
-  auto stripGroup = [&](size_t End) -> size_t {
-    size_t p = End;
+  size_t end = len;
+
+  // Drop a trailing "_code" marker, but only when it follows a "_<digits>"
+  // group (otherwise "_code" is part of an identifier, e.g. "process_code").
+  if(end >= 5 && S[end - 5] == '_' && S[end - 4] == 'c' && S[end - 3] == 'o' &&
+     S[end - 2] == 'd' && S[end - 1] == 'e') {
+    size_t p = end - 5;
     while(p > 0 && S[p - 1] >= '0' && S[p - 1] <= '9')
       p--;
-    if(p < End && p > 0 && S[p - 1] == '_')
-      return p - 1;
-    return End;
-  };
-
-  if(len >= 5 && S[len - 5] == '_' && S[len - 4] == 'c' && S[len - 3] == 'o' &&
-     S[len - 2] == 'd' && S[len - 1] == 'e') {
-    // "..._code": only a stamp if preceded by at least one "_<digits>" group,
-    // otherwise "_code" is part of a name (e.g. "process_code").
-    size_t after_code = len - 5;
-    size_t e1 = stripGroup(after_code);
-    if(e1 == after_code)
-      return len;
-    return stripGroup(e1); // optionally a second group ("_<digits>_<digits>_code")
+    if(p < end - 5 && p > 0 && S[p - 1] == '_')
+      end -= 5;
   }
-  return stripGroup(len);
+
+  // Drop all trailing "_<digits>" groups. Non-numeric identifier characters
+  // stop the scan, so "add_string" and "bar_baz" survive while a numeric stamp
+  // like "..._4_9" does not.
+  for(;;) {
+    size_t p = end;
+    while(p > 0 && S[p - 1] >= '0' && S[p - 1] <= '9')
+      p--;
+    if(p < end && p > 0 && S[p - 1] == '_')
+      end = p - 1;
+    else
+      break;
+  }
+  return end;
 }
 
-// Like oxcamlDemangle, but strips the trailing compiler stamp for display.
-char *llvm::oxcamlDemangleNoStamp(std::string_view Mangled) {
-  char *Result = oxcamlDemangle(Mangled);
+char *llvm::oxcamlDemangle(std::string_view Mangled) {
+  char *Result = demangleAnyScheme(Mangled);
   if(Result == nullptr)
     return nullptr;
 
+  // Strip the trailing compiler stamp: it is a non-deterministic counter with
+  // no source meaning, so it is dropped from the demangled name.
   size_t len = 0;
   while(Result[len] != '\0')
     len++;

--- a/llvm/lib/Demangle/OxCamlDemangle.cpp
+++ b/llvm/lib/Demangle/OxCamlDemangle.cpp
@@ -11,6 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 #include <cassert>
+#include <limits>
+#include <optional>
 #include <string_view>
 
 #include "llvm/Demangle/StringViewExtras.h"
@@ -20,39 +22,37 @@
 using llvm::itanium_demangle::starts_with;
 using llvm::itanium_demangle::OutputBuffer;
 
-// Sentinel returned by the Consume* helpers when no digits could be parsed, or
-// the value would overflow. All callers must treat it as a parse failure.
-static constexpr unsigned kParseError = ~0u;
-
-static unsigned ConsumeUnsignedDecimal(std::string_view &sv) {
+// The Consume* helpers return std::nullopt when no digits could be parsed, or
+// the value would overflow; all callers must treat that as a parse failure.
+static std::optional<unsigned> ConsumeUnsignedDecimal(std::string_view &sv) {
   unsigned res = 0, i = 0;
   while (i < sv.size() && sv[i] >= '0' && sv[i] <= '9') {
-    unsigned digit = (unsigned)(sv[i] - '0');
+    unsigned digit = static_cast<unsigned>(sv[i] - '0');
     // Reject values that would overflow, mirroring the compiler's
     // int_of_string_opt, rather than wrapping silently.
-    if (res > (kParseError - digit) / 10)
-      return kParseError;
+    if (res > (std::numeric_limits<unsigned>::max() - digit) / 10)
+      return std::nullopt;
     res = res * 10 + digit;
     i++;
   }
   sv.remove_prefix(i);
   if (i == 0)
-    return kParseError;
+    return std::nullopt;
   return res;
 }
 
-static unsigned ConsumeUnsigned26(std::string_view &sv) {
+static std::optional<unsigned> ConsumeUnsigned26(std::string_view &sv) {
   unsigned res = 0, i = 0;
   while (i < sv.size() && sv[i] >= 'A' && sv[i] <= 'Z') {
-    unsigned digit = (unsigned)(sv[i] - 'A');
-    if (res > (kParseError - digit) / 26)
-      return kParseError;
+    unsigned digit = static_cast<unsigned>(sv[i] - 'A');
+    if (res > (std::numeric_limits<unsigned>::max() - digit) / 26)
+      return std::nullopt;
     res = res * 26 + digit;
     i++;
   }
   sv.remove_prefix(i);
   if (i == 0)
-    return kParseError;
+    return std::nullopt;
   return res;
 }
 
@@ -72,9 +72,10 @@ static unsigned lowerhex(char c) {
 // Decode escaped identifier (format: u<len><coded>_<raw>)
 // Returns true on success, false on error
 static bool DecodeEscaped(std::string_view& Mangled, OutputBuffer& Demangled) {
-  unsigned len = ConsumeUnsignedDecimal(Mangled);
-  if(len == kParseError || len <= 0 || len > Mangled.size())
+  std::optional<unsigned> lenOpt = ConsumeUnsignedDecimal(Mangled);
+  if(!lenOpt || *lenOpt == 0 || *lenOpt > Mangled.size())
     return false;
+  unsigned len = *lenOpt;
 
   size_t split = Mangled.find('_');
   if(split >= len)
@@ -84,9 +85,10 @@ static bool DecodeEscaped(std::string_view& Mangled, OutputBuffer& Demangled) {
   std::string_view raw = Mangled.substr(split+1, len-split-1);
 
   while(!coded.empty()) {
-    unsigned chunklen = ConsumeUnsigned26(coded);
-    if(chunklen == kParseError || chunklen > raw.size())
+    std::optional<unsigned> chunklenOpt = ConsumeUnsigned26(coded);
+    if(!chunklenOpt || *chunklenOpt > raw.size())
       return false;
+    unsigned chunklen = *chunklenOpt;
     Demangled << raw.substr(0, chunklen);
     raw.remove_prefix(chunklen);
 
@@ -117,9 +119,10 @@ static bool DecodeIdentifier(std::string_view& Mangled, OutputBuffer& Demangled)
     return DecodeEscaped(Mangled, Demangled);
   } else {
     // Plain identifier with length prefix
-    unsigned len = ConsumeUnsignedDecimal(Mangled);
-    if(len == kParseError || len <= 0 || len > Mangled.size())
+    std::optional<unsigned> lenOpt = ConsumeUnsignedDecimal(Mangled);
+    if(!lenOpt || *lenOpt == 0 || *lenOpt > Mangled.size())
       return false;
+    unsigned len = *lenOpt;
     Demangled << Mangled.substr(0, len);
     Mangled.remove_prefix(len);
     return true;
@@ -236,12 +239,14 @@ static char *demangleStructured(std::string_view Mangled) {
   Mangled.remove_prefix(prefix_len);
 
   // Allocate the buffer at a reasonable size, as OutputBuffer allocates 992
-  // bytes when starting from an empty buffer
-  char *DemangledBuffer;
-  DemangledBuffer = static_cast<char *>(std::malloc(Mangled.size()));
+  // bytes when starting from an empty buffer. Add one so the allocation is never
+  // zero (malloc(0) may return nullptr, which we treat as failure) for an empty
+  // path such as "_Caml"; OutputBuffer grows on demand if the path is longer.
+  size_t buffer_size = Mangled.size() + 1;
+  char *DemangledBuffer = static_cast<char *>(std::malloc(buffer_size));
   if (DemangledBuffer == nullptr)
     std::terminate();
-  OutputBuffer Demangled(DemangledBuffer, Mangled.size());
+  OutputBuffer Demangled(DemangledBuffer, buffer_size);
 
   // Free the output buffer and report failure; used on every error path below.
   auto fail = [&]() -> char * {

--- a/llvm/lib/Demangle/OxCamlDemangle.cpp
+++ b/llvm/lib/Demangle/OxCamlDemangle.cpp
@@ -193,7 +193,8 @@ static bool DecodeAnonymousLocation(std::string_view& Mangled, OutputBuffer& Dem
   return true;
 }
 
-char *llvm::oxcamlDemangle(std::string_view Mangled) {
+// Demangle a symbol in the structured scheme (prefix "_Caml").
+static char *demangleStructured(std::string_view Mangled) {
   if(!starts_with(Mangled, "_Caml"))
     return nullptr;
   Mangled.remove_prefix(5);
@@ -271,4 +272,233 @@ char *llvm::oxcamlDemangle(std::string_view Mangled) {
   Demangled << '\0';
 
   return Demangled.getBuffer();
+}
+
+// ===========================================================================
+// Flat scheme (legacy "caml"/"_caml" prefixes)
+//
+// Ports the flat0 (OCaml <= 5.2) and flat1 (OCaml >= 5.3) demanglers from the
+// ocamlfilt reference tool. flat0 uses "__" as the module separator and "$xx"
+// hex escapes. flat1 additionally supports the macOS assembler flavour, which
+// uses "$" as the separator and "$$xx"/"$$$xx" escapes; the flavour is
+// auto-detected per symbol. As with the structured scheme, the trailing
+// compiler suffix (e.g. "_42") is preserved verbatim.
+// ===========================================================================
+
+static bool IsUpperAZ(char c) { return c >= 'A' && c <= 'Z'; }
+
+static bool IsFlatXDigit(char c) {
+  return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') ||
+         (c >= 'A' && c <= 'F');
+}
+
+static unsigned FlatHex(char c) {
+  if(c >= '0' && c <= '9')
+    return c - '0';
+  if(c >= 'a' && c <= 'f')
+    return c - 'a' + 10;
+  return c - 'A' + 10;
+}
+
+// If Mangled starts with a recognised flat prefix ("caml", or the
+// underscore-prefixed "_caml" that the macOS assembler emits) followed by an
+// uppercase letter (a syntactically valid OCaml module name), return the
+// matched prefix length; otherwise return 0.
+static size_t MatchedFlatPrefixLen(std::string_view Mangled) {
+  if(Mangled.size() > 5 && starts_with(Mangled, "_caml") && IsUpperAZ(Mangled[5]))
+    return 5;
+  if(Mangled.size() > 4 && starts_with(Mangled, "caml") && IsUpperAZ(Mangled[4]))
+    return 4;
+  return 0;
+}
+
+enum class FlatStyle { Linux, Macos };
+
+// flat1 emits one of two flavours per binary. A bare '.' or "__" is a positive
+// Linux marker; "$$" or a '$' not followed by two hex digits is a positive
+// macOS marker. A '$' followed by two hex digits is ambiguous in isolation, so
+// if no Linux marker appears anywhere the only coherent reading is macOS.
+static FlatStyle DetectFlatStyle(std::string_view S, size_t PrefixLen) {
+  size_t len = S.size();
+  bool saw_dollar_hex_pair = false;
+  for(size_t i = PrefixLen; i < len;) {
+    if(S[i] == '.')
+      return FlatStyle::Linux;
+    if(S[i] == '_' && i + 1 < len && S[i + 1] == '_')
+      return FlatStyle::Linux;
+    if(S[i] == '$') {
+      if(i + 1 < len && S[i + 1] == '$')
+        return FlatStyle::Macos;
+      if(i + 2 < len && IsFlatXDigit(S[i + 1]) && IsFlatXDigit(S[i + 2])) {
+        saw_dollar_hex_pair = true;
+        i += 3;
+        continue;
+      }
+      return FlatStyle::Macos;
+    }
+    i++;
+  }
+  return saw_dollar_hex_pair ? FlatStyle::Macos : FlatStyle::Linux;
+}
+
+// flat0 (OCaml <= 5.2): "__" -> '.', "$xx" -> hex char, else literal. Returns a
+// malloc'd C string.
+static char *demangleFlat0(std::string_view S, size_t PrefixLen) {
+  size_t len = S.size();
+  char *Out = static_cast<char *>(std::malloc(len + 1));
+  if(Out == nullptr)
+    std::terminate();
+
+  size_t j = 0;
+  for(size_t i = PrefixLen; i < len;) {
+    if(S[i] == '_') {
+      if(i + 1 >= len)
+        break; // dangling '_' -> stop
+      if(S[i + 1] == '_') {
+        Out[j++] = '.';
+        i += 2;
+        continue;
+      }
+      Out[j++] = '_';
+      i++;
+      continue;
+    }
+    if(S[i] == '$') {
+      if(i + 2 < len && IsFlatXDigit(S[i + 1]) && IsFlatXDigit(S[i + 2])) {
+        Out[j++] = (char)((FlatHex(S[i + 1]) << 4) | FlatHex(S[i + 2]));
+        i += 3;
+        continue;
+      }
+      Out[j++] = '$'; // not a valid escape -> literal '$'
+      i++;
+      continue;
+    }
+    Out[j++] = S[i++];
+  }
+  Out[j] = '\0';
+  return Out;
+}
+
+// flat1 (OCaml >= 5.3): Linux flavour matches flat0; the macOS flavour uses '$'
+// as the separator with "$$xx" / "$$$xx" escapes. Returns a malloc'd C string.
+static char *demangleFlat1(std::string_view S, size_t PrefixLen) {
+  size_t len = S.size();
+  FlatStyle style = DetectFlatStyle(S, PrefixLen);
+  char *Out = static_cast<char *>(std::malloc(len + 1));
+  if(Out == nullptr)
+    std::terminate();
+
+  size_t j = 0;
+  for(size_t i = PrefixLen; i < len;) {
+    if(style == FlatStyle::Macos) {
+      if(S[i] != '$') {
+        Out[j++] = S[i++];
+        continue;
+      }
+      if(i + 4 < len && S[i + 1] == '$' && S[i + 2] == '$' &&
+         IsFlatXDigit(S[i + 3]) && IsFlatXDigit(S[i + 4])) {
+        // "$$$xx" -> separator + hex char
+        Out[j++] = '.';
+        Out[j++] = (char)((FlatHex(S[i + 3]) << 4) | FlatHex(S[i + 4]));
+        i += 5;
+        continue;
+      }
+      if(i + 3 < len && S[i + 1] == '$' && IsFlatXDigit(S[i + 2]) &&
+         IsFlatXDigit(S[i + 3])) {
+        // "$$xx" -> hex char
+        Out[j++] = (char)((FlatHex(S[i + 2]) << 4) | FlatHex(S[i + 3]));
+        i += 4;
+        continue;
+      }
+      // bare '$' -> separator
+      Out[j++] = '.';
+      i++;
+      continue;
+    }
+
+    // Linux flavour
+    if(S[i] == '$') {
+      if(i + 2 < len && IsFlatXDigit(S[i + 1]) && IsFlatXDigit(S[i + 2])) {
+        Out[j++] = (char)((FlatHex(S[i + 1]) << 4) | FlatHex(S[i + 2]));
+        i += 3;
+        continue;
+      }
+      Out[j++] = '$';
+      i++;
+      continue;
+    }
+    if(S[i] == '_' && i + 1 < len && S[i + 1] == '_') {
+      Out[j++] = '.';
+      i += 2;
+      continue;
+    }
+    Out[j++] = S[i++];
+  }
+  Out[j] = '\0';
+  return Out;
+}
+
+bool llvm::isOxCamlMangledName(std::string_view MangledName) {
+  return starts_with(MangledName, "_Caml") ||
+         MatchedFlatPrefixLen(MangledName) != 0;
+}
+
+char *llvm::oxcamlDemangle(std::string_view Mangled) {
+  if(starts_with(Mangled, "_Caml"))
+    return demangleStructured(Mangled);
+
+  if(size_t PrefixLen = MatchedFlatPrefixLen(Mangled)) {
+    // flat1 (>= 5.3) is a superset of flat0; only fall back to flat0 (<= 5.2)
+    // if flat1 rejects the symbol.
+    if(char *Result = demangleFlat1(Mangled, PrefixLen))
+      return Result;
+    return demangleFlat0(Mangled, PrefixLen);
+  }
+
+  return nullptr;
+}
+
+// Length of the demangled name S[0..len) with any trailing OCaml compiler stamp
+// removed. The stamp is a non-deterministic counter (plus an optional "_code"
+// marker for code symbols) the compiler appends to keep linker symbols unique;
+// it is unstable across builds and carries no source meaning. Recognised
+// trailing forms: "_<digits>_<digits>_code", "_<digits>_code", "_<digits>".
+// Source spans ("[...]"/"(...)") and operator/identifier characters are kept,
+// since they do not end in "_<digits>".
+static size_t lengthWithoutStamp(const char *S, size_t len) {
+  // Strip one trailing "_<digits>" group ending at End; return the new end, or
+  // End unchanged when there is no such group.
+  auto stripGroup = [&](size_t End) -> size_t {
+    size_t p = End;
+    while(p > 0 && S[p - 1] >= '0' && S[p - 1] <= '9')
+      p--;
+    if(p < End && p > 0 && S[p - 1] == '_')
+      return p - 1;
+    return End;
+  };
+
+  if(len >= 5 && S[len - 5] == '_' && S[len - 4] == 'c' && S[len - 3] == 'o' &&
+     S[len - 2] == 'd' && S[len - 1] == 'e') {
+    // "..._code": only a stamp if preceded by at least one "_<digits>" group,
+    // otherwise "_code" is part of a name (e.g. "process_code").
+    size_t after_code = len - 5;
+    size_t e1 = stripGroup(after_code);
+    if(e1 == after_code)
+      return len;
+    return stripGroup(e1); // optionally a second group ("_<digits>_<digits>_code")
+  }
+  return stripGroup(len);
+}
+
+// Like oxcamlDemangle, but strips the trailing compiler stamp for display.
+char *llvm::oxcamlDemangleNoStamp(std::string_view Mangled) {
+  char *Result = oxcamlDemangle(Mangled);
+  if(Result == nullptr)
+    return nullptr;
+
+  size_t len = 0;
+  while(Result[len] != '\0')
+    len++;
+  Result[lengthWithoutStamp(Result, len)] = '\0';
+  return Result;
 }

--- a/llvm/lib/Demangle/OxCamlDemangle.cpp
+++ b/llvm/lib/Demangle/OxCamlDemangle.cpp
@@ -1,0 +1,274 @@
+//===--- OxCamlDemangle.cpp -------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines a demangler for the new mangling scheme devised for OxCaml
+//
+//===----------------------------------------------------------------------===//
+
+#include <cassert>
+#include <string_view>
+
+#include "llvm/Demangle/StringViewExtras.h"
+#include "llvm/Demangle/Demangle.h"
+#include "llvm/Demangle/Utility.h"
+
+using llvm::itanium_demangle::starts_with;
+using llvm::itanium_demangle::OutputBuffer;
+
+#define ERROR (~((unsigned)0))
+
+static unsigned ConsumeUnsignedDecimal(std::string_view& sv) {
+  unsigned res = 0, i = 0;
+  while(sv[i] >= '0' && sv[i] <= '9') {
+    res = res * 10 + (sv[i] - '0');
+    i++;
+  }
+  sv.remove_prefix(i);
+  if(i == 0)
+    return ERROR;
+  return res;
+}
+
+static unsigned ConsumeUnsigned26(std::string_view& sv) {
+  unsigned res = 0, i = 0;
+  while(sv[i] >= 'A' && sv[i] <= 'Z') {
+    res = res * 26 + (sv[i] - 'A');
+    i++;
+  }
+  sv.remove_prefix(i);
+  if(i == 0)
+    return ERROR;
+  return res;
+}
+
+static bool islowerhex(char c) {
+  return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f');
+}
+
+static unsigned lowerhex(char c) {
+  if(c >= '0' && c <= '9')
+    return c - '0';
+  else {
+    assert(c >= 'a' && c <= 'f');
+    return c - 'a' + 10;
+  }
+}
+
+// Decode escaped identifier (format: u<len><coded>_<raw>)
+// Returns true on success, false on error
+static bool DecodeEscaped(std::string_view& Mangled, OutputBuffer& Demangled) {
+  unsigned len = ConsumeUnsignedDecimal(Mangled);
+  if(len == ERROR || len <= 0 || len > Mangled.size())
+    return false;
+
+  size_t split = Mangled.find('_');
+  if(split >= len)
+    return false;
+
+  std::string_view coded = Mangled.substr(0, split);
+  std::string_view raw = Mangled.substr(split+1, len-split-1);
+
+  while(!coded.empty()) {
+    unsigned chunklen = ConsumeUnsigned26(coded);
+    if(chunklen == ERROR || chunklen > raw.size())
+      return false;
+    Demangled << raw.substr(0, chunklen);
+    raw.remove_prefix(chunklen);
+
+    unsigned i;
+    for(i = 0; i+1 < coded.size() && islowerhex(coded[i]); i+=2) {
+      if(!islowerhex(coded[i+1]))
+        return false;
+      char c = (char)(lowerhex(coded[i]) << 4 | lowerhex(coded[i+1]));
+      Demangled << c;
+    }
+    coded.remove_prefix(i);
+  }
+
+  if(!raw.empty())
+    Demangled << raw;
+
+  Mangled.remove_prefix(len);
+  return true;
+}
+
+// Decode identifier (either plain or escaped)
+// Handles: <len><text> or u<len><coded>_<raw>
+// Returns true on success, false on error
+static bool DecodeIdentifier(std::string_view& Mangled, OutputBuffer& Demangled) {
+  if(starts_with(Mangled, 'u')) {
+    // Escaped identifier
+    Mangled.remove_prefix(1);
+    return DecodeEscaped(Mangled, Demangled);
+  } else {
+    // Plain identifier with length prefix
+    unsigned len = ConsumeUnsignedDecimal(Mangled);
+    if(len == ERROR || len <= 0 || len > Mangled.size())
+      return false;
+    Demangled << Mangled.substr(0, len);
+    Mangled.remove_prefix(len);
+    return true;
+  }
+}
+
+// Decode anonymous location (format: filename_line_col)
+// Anonymous functions, modules and partial functions are encoded as:
+//   type(filename:line:col)
+// where <type> can be fn, mod or partial
+// Returns true on success, false on error
+static bool DecodeAnonymousLocation(std::string_view& Mangled, OutputBuffer& Demangled, char typ) {
+  // Allocate temporary buffer based on remaining mangled string size
+  // The decoded identifier will be at most the size of the remaining mangled string
+  size_t buffer_size = Mangled.size();
+  if(buffer_size == 0)
+    return false;
+
+  char *temp_buf = static_cast<char *>(std::malloc(buffer_size));
+  if(temp_buf == nullptr)
+    std::terminate();
+
+  OutputBuffer TempDemangled(temp_buf, buffer_size);
+
+  if(!DecodeIdentifier(Mangled, TempDemangled)) {
+    std::free(TempDemangled.getBuffer());
+    return false;
+  }
+
+  size_t temp_len = TempDemangled.getCurrentPosition();
+  char *buf = TempDemangled.getBuffer();
+
+  // Parse filename_line_col format by finding the last two underscores
+  size_t first_underscore = 0, second_underscore = 0;
+  int underscore_count = 0;
+
+  for(size_t j = temp_len; j > 0; j--) {
+    if(buf[j-1] == '_') {
+      underscore_count++;
+      if(underscore_count == 1)
+        second_underscore = j - 1;
+      else if(underscore_count == 2) {
+        first_underscore = j - 1;
+        break;
+      }
+    }
+  }
+
+  // Output in format type(filename:line:col)
+  if(underscore_count >= 2) {
+    switch(typ) {
+      case 'S':
+        Demangled << "mod";
+        break;
+      case 'L':
+        Demangled << "fn";
+        break;
+      case 'P':
+        Demangled << "partial";
+        break;
+      default:
+        assert(0);
+    }
+    Demangled << '(';
+    for(size_t j = 0; j < first_underscore; j++)
+      Demangled << buf[j];
+    Demangled << ':';
+    for(size_t j = first_underscore + 1; j < second_underscore; j++)
+      Demangled << buf[j];
+    Demangled << ':';
+    for(size_t j = second_underscore + 1; j < temp_len; j++)
+      Demangled << buf[j];
+    Demangled << ')';
+  } else {
+    // Fallback: just output the identifier as-is
+    for(size_t j = 0; j < temp_len; j++)
+      Demangled << buf[j];
+  }
+
+  std::free(buf);
+  return true;
+}
+
+char *llvm::oxcamlDemangle(std::string_view Mangled) {
+  if(!starts_with(Mangled, "_Caml"))
+    return nullptr;
+  Mangled.remove_prefix(5);
+
+  // Allocate the buffer at a reasonable size, as OutputBuffer allocates 992
+  // bytes when starting from an empty buffer
+  char *DemangledBuffer;
+  DemangledBuffer = static_cast<char *>(std::malloc(Mangled.size()));
+  if (DemangledBuffer == nullptr)
+    std::terminate();
+  OutputBuffer Demangled(DemangledBuffer, Mangled.size());
+
+#define ENDONERROR() do {           \
+  std::free(Demangled.getBuffer()); \
+  return nullptr;                   \
+} while(0)
+
+  // Parse path items
+  while(!Mangled.empty()) {
+      // Check for terminating underscore
+      if(Mangled[0] == '_') {
+          // End of symbol path, rest is unique id
+          break;
+      }
+
+      // Handle each path_item type
+      switch(Mangled[0]) {
+          case 'U':  // Compilation Unit
+          case 'M':  // Module
+          case 'O':  // class (O for object)
+          case 'F':  // Function
+              if(!Demangled.empty())
+                  Demangled << '.';
+              Mangled.remove_prefix(1);
+              if(!DecodeIdentifier(Mangled, Demangled))
+                  ENDONERROR();
+              break;
+
+          case 'S':  // anonymous Struct
+          case 'L':  // anonymous function (L for lambda)
+          case 'P': { // Partial application
+              if(!Demangled.empty())
+                  Demangled << '.';
+              char typ = Mangled[0];
+              Mangled.remove_prefix(1);
+              if(!DecodeAnonymousLocation(Mangled, Demangled, typ))
+                  ENDONERROR();
+              break;
+          }
+          case 'I':  // Inline marker (specialization)
+              if(!Demangled.empty())
+                  Demangled << '.';
+              Mangled.remove_prefix(1);
+              // The body was specialized (copied) into the current compilation
+              // unit, not inlined at a particular call site, so render
+              // <specialization_of> to match the ocamlfilt reference demangler.
+              Demangled << "<specialization_of>";
+              break;
+
+          default:
+              ENDONERROR();
+      }
+  }
+
+  // A valid symbol must contain at least one path item; reject names like
+  // "_Caml" or "_Caml_123" that decoded to nothing.
+  if(Demangled.getCurrentPosition() == 0)
+      ENDONERROR();
+
+  // Append the trailing suffix (compiler-appended unique ids such as "_5_code")
+  // verbatim. They keep otherwise-identical symbols distinct, so dropping them
+  // would risk name clashes.
+  Demangled << Mangled;
+
+  Demangled << '\0';
+
+  return Demangled.getBuffer();
+}

--- a/llvm/unittests/Demangle/CMakeLists.txt
+++ b/llvm/unittests/Demangle/CMakeLists.txt
@@ -10,4 +10,5 @@ add_llvm_unittest(DemangleTests
   OutputBufferTest.cpp
   PartialDemangleTest.cpp
   RustDemangleTest.cpp
+  OxCamlDemangleTest.cpp
 )

--- a/llvm/unittests/Demangle/OxCamlDemangleTest.cpp
+++ b/llvm/unittests/Demangle/OxCamlDemangleTest.cpp
@@ -1,0 +1,116 @@
+//===------------------ OxCamlDemangleTest.cpp ------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Demangle/Demangle.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include <cstdlib>
+
+/* How to reproduce the symbols tested in the present file
+
+cat > main.ml << EOF
+let say_hello () = ()
+
+module Test = struct
+  let foo () = ()
+end
+
+let main () = ignore (List.map2 (fun x -> let f y = y * x * 2 in f) [] [])
+
+let _ = ignore (List.map say_hello [])
+EOF
+
+ocamlopt -o main main.ml
+nm -pa main | awk '/_Caml.*(Main|[0-9]map_[0-9])/ { print $3 }'
+*/
+
+
+namespace {
+struct DemangleCase {
+    const char *Mangled;
+    const char *Expected; // nullptr means the input must be rejected
+};
+
+void CheckDemangle(const DemangleCase &C) {
+    char *Demangled = llvm::oxcamlDemangle(C.Mangled);
+    if (C.Expected == nullptr)
+        EXPECT_EQ(Demangled, nullptr) << "expected rejection of: " << C.Mangled;
+    else
+        EXPECT_STREQ(Demangled, C.Expected) << "input: " << C.Mangled;
+    std::free(Demangled);
+}
+} // namespace
+
+// Golden corpus from oxcaml/oxcaml PR #5100, the pure-OCaml `ocamlfilt`
+// reference demangler (testsuite/tests/tool-ocamlfilt/structured.{sh,reference}).
+// Our output must match `ocamlfilt --format structured` exactly, including the
+// trailing compiler suffix (kept verbatim to avoid name clashes).
+TEST(OxCamlDemangle, StructuredCorpus) {
+    static const DemangleCase Cases[] = {
+        {"_CamlU3FooM3BarF3baz", "Foo.Bar.baz"},
+        {"_CamlU6StdlibF3map", "Stdlib.map"},
+        {"_CamlU3FooO5MyObj", "Foo.MyObj"},                 // class (O)
+        {"_CamlU3FooIU3BarF3qux",                           // inline marker (I)
+         "Foo.<specialization_of>.Bar.qux"},
+        {"_CamlU3FooFu8A3e3e3d_", "Foo.>>="},               // escaped: bytes only
+        {"_CamlU3FooFu7D2a_let", "Foo.let*"},               // escaped: one chunk
+        {"_CamlU3FooFu14E27D27_funcsub", "Foo.func'sub'"},  // escaped: two chunks
+        {"_CamlU6StdlibLu18G2e_stdlibml_334_0",
+         "Stdlib.fn(stdlib.ml:334:0)"},
+        {"_CamlU3FooS5_42_7", "Foo.mod(:42:7)"},            // empty filename
+        {"_CamlU3FooP5_10_5", "Foo.partial(:10:5)"},        // partial, empty file
+        {"_CamlU3FooM3BarM3BazF6my_fun", "Foo.Bar.Baz.my_fun"},
+        {"_CamlU3FooFu5_0foo", "Foo.0foo"},                 // digit-leading name
+        {"_CamlU4MainF11say_hello_0_5_code",                // suffix kept verbatim
+         "Main.say_hello_0_5_code"},
+        {"_CamlU4MainM4TestF5foo_1_6_code", "Main.Test.foo_1_6_code"},
+        {"_CamlU12Stdlib__ListF6map_15_113_code",           // __ pack separator
+         "Stdlib__List.map_15_113_code"},
+        {"_CamlU4MainSu15E2e_testml_5_15_300",
+         "Main.mod(test.ml:5:15)_300"},
+        {"_CamlU4MainF4mainLu15E2e_mainml_7_32F4fn_4_9_code",
+         "Main.main.fn(main.ml:7:32).fn_4_9_code"},
+        {"_CamlU3FooF3barLu14D2e_fooml_3_15Lu14D2e_fooml_4_22F4fn_7", // nested
+         "Foo.bar.fn(foo.ml:3:15).fn(foo.ml:4:22).fn_7"},
+        {"_CamlU3FooM3BarLu14D2e_fooml_5_10F3bazF4fn_1_2",
+         "Foo.Bar.fn(foo.ml:5:10).baz.fn_1_2"},
+        {"_CamlU8Functor2F8combinedLu14D2e_fooml_8_12F4fn_1_3_code",
+         "Functor2.combined.fn(foo.ml:8:12).fn_1_3_code"},
+        {"_CamlU3FooSu14D2e_fooml_2_10F4initF4fn_5_6",
+         "Foo.mod(foo.ml:2:10).init.fn_5_6"},
+        {"_CamlU3FooF3barPu14D2e_fooml_9_15", "Foo.bar.partial(foo.ml:9:15)"},
+        {"_CamlU3FooM3BarIU3BazF3qux", "Foo.Bar.<specialization_of>.Baz.qux"},
+        {"_CamlU3FooM3BarO5ShapeF4area", "Foo.Bar.Shape.area"},
+    };
+    for (const auto &C : Cases)
+        CheckDemangle(C);
+}
+
+// Inputs that must be rejected, from PR #5100 reject.{sh,reference} plus the
+// empty-path case. The macOS "__Caml" and lowercase flat "__caml" prefixes are
+// stripped/handled by surrounding lldb code, so the demangler proper only
+// accepts the "_Caml" prefix.
+TEST(OxCamlDemangle, RejectCorpus) {
+    static const DemangleCase Cases[] = {
+        {"_Caml", nullptr},                       // valid prefix, empty path
+        {"_ABCDEF", nullptr},                     // wrong prefix
+        {"main", nullptr},
+        {"_ZN4testE", nullptr},                   // Itanium C++ mangling
+        {"caml_foo", nullptr},
+        {"_CamlU3FooXXX", nullptr},               // unknown path-item tag
+        {"_CamlU99Foo", nullptr},                 // length overruns input
+        {"_CamlUFoo", nullptr},                   // missing length prefix
+        {"_CamlU3FooFu6G1234_funcsub", nullptr},  // base26 position > raw length
+        {"_CamlU3FooFu11G2g_funcsub", nullptr},   // 'g' is not a hex digit
+        {"_CamlU3FooFu11G2A_funcsub", nullptr},   // 'A' where a hex digit is due
+        {"__camlFoo__bar_0", nullptr},            // flat (lowercase) scheme
+    };
+    for (const auto &C : Cases)
+        CheckDemangle(C);
+}

--- a/llvm/unittests/Demangle/OxCamlDemangleTest.cpp
+++ b/llvm/unittests/Demangle/OxCamlDemangleTest.cpp
@@ -47,10 +47,9 @@ void CheckDemangle(const DemangleCase &C) {
 }
 } // namespace
 
-// Golden corpus from oxcaml/oxcaml PR #5100, the pure-OCaml `ocamlfilt`
-// reference demangler (testsuite/tests/tool-ocamlfilt/structured.{sh,reference}).
-// Our output must match `ocamlfilt --format structured` exactly, including the
-// trailing compiler suffix (kept verbatim to avoid name clashes).
+// Corpus from oxcaml/oxcaml PR #5100, the pure-OCaml `ocamlfilt` reference
+// demangler (testsuite/tests/tool-ocamlfilt/structured.{sh,reference}), with the
+// non-deterministic trailing compiler stamp dropped (oxcamlDemangle strips it).
 TEST(OxCamlDemangle, StructuredCorpus) {
     static const DemangleCase Cases[] = {
         {"_CamlU3FooM3BarF3baz", "Foo.Bar.baz"},
@@ -67,23 +66,23 @@ TEST(OxCamlDemangle, StructuredCorpus) {
         {"_CamlU3FooP5_10_5", "Foo.partial(:10:5)"},        // partial, empty file
         {"_CamlU3FooM3BarM3BazF6my_fun", "Foo.Bar.Baz.my_fun"},
         {"_CamlU3FooFu5_0foo", "Foo.0foo"},                 // digit-leading name
-        {"_CamlU4MainF11say_hello_0_5_code",                // suffix kept verbatim
-         "Main.say_hello_0_5_code"},
-        {"_CamlU4MainM4TestF5foo_1_6_code", "Main.Test.foo_1_6_code"},
+        {"_CamlU4MainF11say_hello_0_5_code",                // stamp stripped
+         "Main.say_hello"},
+        {"_CamlU4MainM4TestF5foo_1_6_code", "Main.Test.foo"},
         {"_CamlU12Stdlib__ListF6map_15_113_code",           // __ pack separator
-         "Stdlib__List.map_15_113_code"},
-        {"_CamlU4MainSu15E2e_testml_5_15_300",
-         "Main.mod(test.ml:5:15)_300"},
+         "Stdlib__List.map"},
+        {"_CamlU4MainSu15E2e_testml_5_15_300",              // span kept, stamp dropped
+         "Main.mod(test.ml:5:15)"},
         {"_CamlU4MainF4mainLu15E2e_mainml_7_32F4fn_4_9_code",
-         "Main.main.fn(main.ml:7:32).fn_4_9_code"},
+         "Main.main.fn(main.ml:7:32).fn"},
         {"_CamlU3FooF3barLu14D2e_fooml_3_15Lu14D2e_fooml_4_22F4fn_7", // nested
-         "Foo.bar.fn(foo.ml:3:15).fn(foo.ml:4:22).fn_7"},
+         "Foo.bar.fn(foo.ml:3:15).fn(foo.ml:4:22).fn"},
         {"_CamlU3FooM3BarLu14D2e_fooml_5_10F3bazF4fn_1_2",
-         "Foo.Bar.fn(foo.ml:5:10).baz.fn_1_2"},
+         "Foo.Bar.fn(foo.ml:5:10).baz.fn"},
         {"_CamlU8Functor2F8combinedLu14D2e_fooml_8_12F4fn_1_3_code",
-         "Functor2.combined.fn(foo.ml:8:12).fn_1_3_code"},
+         "Functor2.combined.fn(foo.ml:8:12).fn"},
         {"_CamlU3FooSu14D2e_fooml_2_10F4initF4fn_5_6",
-         "Foo.mod(foo.ml:2:10).init.fn_5_6"},
+         "Foo.mod(foo.ml:2:10).init.fn"},
         {"_CamlU3FooF3barPu14D2e_fooml_9_15", "Foo.bar.partial(foo.ml:9:15)"},
         {"_CamlU3FooM3BarIU3BazF3qux", "Foo.Bar.<specialization_of>.Baz.qux"},
         {"_CamlU3FooM3BarO5ShapeF4area", "Foo.Bar.Shape.area"},
@@ -96,36 +95,36 @@ TEST(OxCamlDemangle, StructuredCorpus) {
 // (testsuite/tests/tool-ocamlfilt/flat0.{sh,reference} and flat1.{sh,reference}).
 // flat0 = OCaml <= 5.2 ("__" separators, "$xx" escapes); flat1 = OCaml >= 5.3,
 // which adds the macOS flavour ("$" separators, "$$xx"/"$$$xx" escapes,
-// auto-detected). The trailing compiler suffix is preserved.
+// auto-detected). The non-deterministic trailing compiler stamp is stripped.
 TEST(OxCamlDemangle, FlatCorpus) {
     static const DemangleCase Cases[] = {
         // flat0 (and Linux flat1, which is identical)
         {"camlFoo", "Foo"},
-        {"camlFoo__bar_0", "Foo.bar_0"},
-        {"camlA__B__C__D__func_0", "A.B.C.D.func_0"},
-        {"camlFoo__bar_baz_42", "Foo.bar_baz_42"},
-        {"camlStdlib__array__map_154", "Stdlib.array.map_154"},
-        {"camlBaz__Foo__Bar__init_0", "Baz.Foo.Bar.init_0"},
+        {"camlFoo__bar_0", "Foo.bar"},
+        {"camlA__B__C__D__func_0", "A.B.C.D.func"},
+        {"camlFoo__bar_baz_42", "Foo.bar_baz"},            // name '_' kept
+        {"camlStdlib__array__map_154", "Stdlib.array.map"},
+        {"camlBaz__Foo__Bar__init_0", "Baz.Foo.Bar.init"},
         {"camlFoo__", "Foo."},
-        {"camlStdlib__bytes__$2b$2b_2205", "Stdlib.bytes.++_2205"},
-        {"camlFoo__$2b$2b$2b_1", "Foo.+++_1"},
+        {"camlStdlib__bytes__$2b$2b_2205", "Stdlib.bytes.++"},
+        {"camlFoo__$2b$2b$2b_1", "Foo.+++"},
         {"camlStdlib__anon_fn$5bstdlib$2eml$3a334$2c0$2d$2d54$5d_1453",
-         "Stdlib.anon_fn[stdlib.ml:334,0--54]_1453"},
-        {"_camlFoo__bar_0", "Foo.bar_0"},                  // macOS "_caml" prefix
-        {"_camlStdlib__array__map_154", "Stdlib.array.map_154"},
+         "Stdlib.anon_fn[stdlib.ml:334,0--54]"},           // span kept
+        {"_camlFoo__bar_0", "Foo.bar"},                    // macOS "_caml" prefix
+        {"_camlStdlib__array__map_154", "Stdlib.array.map"},
         // flat1 Linux escapes
-        {"camlFoo__$3e$3e$3d_12", "Foo.>>=_12"},
-        {"camlIndexing__.$25$28$29_2_14_code", "Indexing..%()_2_14_code"},
+        {"camlFoo__$3e$3e$3d_12", "Foo.>>="},
+        {"camlIndexing__.$25$28$29_2_14_code", "Indexing..%()"},
         // flat1 macOS flavour: "$" separator, "$$xx"/"$$$xx" escapes
-        {"camlA$B$C$D$func_0", "A.B.C.D.func_0"},
-        {"camlFoo$$$3e$$3e$$3d_12", "Foo.>>=_12"},
-        {"camlFoo$$$2b$$2b_5", "Foo.++_5"},
-        {"camlIndexing$$$2e$$25$$28$$29_2_14_code", "Indexing..%()_2_14_code"},
+        {"camlA$B$C$D$func_0", "A.B.C.D.func"},
+        {"camlFoo$$$3e$$3e$$3d_12", "Foo.>>="},
+        {"camlFoo$$$2b$$2b_5", "Foo.++"},
+        {"camlIndexing$$$2e$$25$$28$$29_2_14_code", "Indexing..%()"},
         {"camlStdlib$anon_fn$$5bstdlib$$2eml$$3a334$$2c0$$2d$$2d54$$5d_1453",
-         "Stdlib.anon_fn[stdlib.ml:334,0--54]_1453"},
-        {"camlList$add_42", "List.add_42"},
-        {"camlBuffer$add_string_5_28_code", "Buffer.add_string_5_28_code"},
-        {"_camlStdlib__List__map_15_113_code", "Stdlib.List.map_15_113_code"},
+         "Stdlib.anon_fn[stdlib.ml:334,0--54]"},
+        {"camlList$add_42", "List.add"},
+        {"camlBuffer$add_string_5_28_code", "Buffer.add_string"},
+        {"_camlStdlib__List__map_15_113_code", "Stdlib.List.map"},
     };
     for (const auto &C : Cases)
         CheckDemangle(C);
@@ -152,35 +151,4 @@ TEST(OxCamlDemangle, RejectCorpus) {
     };
     for (const auto &C : Cases)
         CheckDemangle(C);
-}
-
-// oxcamlDemangleNoStamp: the display variant strips the trailing compiler
-// stamp ("_<digits>", "_<digits>_code", "_<digits>_<digits>_code") while
-// keeping source spans, operators, and identifier underscores intact.
-static void CheckNoStamp(const char *Mangled, const char *Expected) {
-    char *Demangled = llvm::oxcamlDemangleNoStamp(Mangled);
-    EXPECT_STREQ(Demangled, Expected) << "input: " << Mangled;
-    std::free(Demangled);
-}
-
-TEST(OxCamlDemangle, DisplayNoStamp) {
-    // structured
-    CheckNoStamp("_CamlU3FooM3BarF3baz", "Foo.Bar.baz");        // no stamp
-    CheckNoStamp("_CamlU3FooFu8A3e3e3d_", "Foo.>>=");           // operator, no stamp
-    CheckNoStamp("_CamlU4MainF11say_hello_0_5_code", "Main.say_hello");
-    CheckNoStamp("_CamlU4MainM4TestF5foo_1_6_code", "Main.Test.foo");
-    CheckNoStamp("_CamlU4MainSu15E2e_testml_5_15_300",
-                 "Main.mod(test.ml:5:15)"); // span kept, _300 stripped
-    CheckNoStamp("_CamlU4MainF4mainLu15E2e_mainml_7_32F4fn_4_9_code",
-                 "Main.main.fn(main.ml:7:32).fn");
-    // flat
-    CheckNoStamp("camlFoo__bar_0", "Foo.bar");
-    CheckNoStamp("camlA__B__C__D__func_0", "A.B.C.D.func");
-    CheckNoStamp("camlStdlib__array__map_154", "Stdlib.array.map");
-    CheckNoStamp("camlBuffer$add_string_5_28_code",
-                 "Buffer.add_string"); // internal '_' kept, stamp stripped
-    CheckNoStamp("camlStdlib__anon_fn$5bstdlib$2eml$3a334$2c0$2d$2d54$5d_1453",
-                 "Stdlib.anon_fn[stdlib.ml:334,0--54]"); // span kept
-    // not OxCaml -> nullptr passes through
-    CheckNoStamp("caml_foo", nullptr);
 }

--- a/llvm/unittests/Demangle/OxCamlDemangleTest.cpp
+++ b/llvm/unittests/Demangle/OxCamlDemangleTest.cpp
@@ -48,11 +48,14 @@ void CheckDemangle(const DemangleCase &C) {
 } // namespace
 
 // Corpus from oxcaml/oxcaml PR #5100, the pure-OCaml `ocamlfilt` reference
-// demangler (testsuite/tests/tool-ocamlfilt/structured.{sh,reference}), with the
-// non-deterministic trailing compiler stamp dropped (oxcamlDemangle strips it).
+// demangler (testsuite/tests/tool-ocamlfilt/structured.{sh,reference}). The
+// path is decoded from exact length-prefixed identifiers, so we drop only the
+// compiler-appended suffix that follows the path; identifiers are preserved
+// verbatim, including any trailing digits (e.g. "say_hello_0", "add_2").
 TEST(OxCamlDemangle, StructuredCorpus) {
     static const DemangleCase Cases[] = {
         {"_CamlU3FooM3BarF3baz", "Foo.Bar.baz"},
+        {"__CamlU3FooM3BarF3baz", "Foo.Bar.baz"},           // macOS "__Caml"
         {"_CamlU6StdlibF3map", "Stdlib.map"},
         {"_CamlU3FooO5MyObj", "Foo.MyObj"},                 // class (O)
         {"_CamlU3FooIU3BarF3qux",                           // inline marker (I)
@@ -66,23 +69,24 @@ TEST(OxCamlDemangle, StructuredCorpus) {
         {"_CamlU3FooP5_10_5", "Foo.partial(:10:5)"},        // partial, empty file
         {"_CamlU3FooM3BarM3BazF6my_fun", "Foo.Bar.Baz.my_fun"},
         {"_CamlU3FooFu5_0foo", "Foo.0foo"},                 // digit-leading name
-        {"_CamlU4MainF11say_hello_0_5_code",                // stamp stripped
-         "Main.say_hello"},
-        {"_CamlU4MainM4TestF5foo_1_6_code", "Main.Test.foo"},
+        {"_CamlU3FooF5add_2", "Foo.add_2"},                 // digit-ending name kept
+        {"_CamlU4MainF11say_hello_0_5_code",                // suffix "_5_code" dropped
+         "Main.say_hello_0"},
+        {"_CamlU4MainM4TestF5foo_1_6_code", "Main.Test.foo_1"},
         {"_CamlU12Stdlib__ListF6map_15_113_code",           // __ pack separator
-         "Stdlib__List.map"},
-        {"_CamlU4MainSu15E2e_testml_5_15_300",              // span kept, stamp dropped
+         "Stdlib__List.map_15"},
+        {"_CamlU4MainSu15E2e_testml_5_15_300",              // span kept, suffix dropped
          "Main.mod(test.ml:5:15)"},
         {"_CamlU4MainF4mainLu15E2e_mainml_7_32F4fn_4_9_code",
-         "Main.main.fn(main.ml:7:32).fn"},
+         "Main.main.fn(main.ml:7:32).fn_4"},
         {"_CamlU3FooF3barLu14D2e_fooml_3_15Lu14D2e_fooml_4_22F4fn_7", // nested
-         "Foo.bar.fn(foo.ml:3:15).fn(foo.ml:4:22).fn"},
+         "Foo.bar.fn(foo.ml:3:15).fn(foo.ml:4:22).fn_7"},
         {"_CamlU3FooM3BarLu14D2e_fooml_5_10F3bazF4fn_1_2",
-         "Foo.Bar.fn(foo.ml:5:10).baz.fn"},
+         "Foo.Bar.fn(foo.ml:5:10).baz.fn_1"},
         {"_CamlU8Functor2F8combinedLu14D2e_fooml_8_12F4fn_1_3_code",
-         "Functor2.combined.fn(foo.ml:8:12).fn"},
+         "Functor2.combined.fn(foo.ml:8:12).fn_1"},
         {"_CamlU3FooSu14D2e_fooml_2_10F4initF4fn_5_6",
-         "Foo.mod(foo.ml:2:10).init.fn"},
+         "Foo.mod(foo.ml:2:10).init.fn_5"},
         {"_CamlU3FooF3barPu14D2e_fooml_9_15", "Foo.bar.partial(foo.ml:9:15)"},
         {"_CamlU3FooM3BarIU3BazF3qux", "Foo.Bar.<specialization_of>.Baz.qux"},
         {"_CamlU3FooM3BarO5ShapeF4area", "Foo.Bar.Shape.area"},
@@ -91,14 +95,12 @@ TEST(OxCamlDemangle, StructuredCorpus) {
         CheckDemangle(C);
 }
 
-// Golden corpus for the legacy flat schemes from oxcaml/oxcaml PR #5100
-// (testsuite/tests/tool-ocamlfilt/flat0.{sh,reference} and flat1.{sh,reference}).
-// flat0 = OCaml <= 5.2 ("__" separators, "$xx" escapes); flat1 = OCaml >= 5.3,
-// which adds the macOS flavour ("$" separators, "$$xx"/"$$$xx" escapes,
-// auto-detected). The non-deterministic trailing compiler stamp is stripped.
+// Golden corpus for the legacy flat0 scheme (OCaml <= 5.2) from oxcaml/oxcaml
+// PR #5100 (testsuite/tests/tool-ocamlfilt/flat0.{sh,reference}): "__"
+// separators and "$xx" hex escapes. The trailing compiler stamp is stripped
+// heuristically.
 TEST(OxCamlDemangle, FlatCorpus) {
     static const DemangleCase Cases[] = {
-        // flat0 (and Linux flat1, which is identical)
         {"camlFoo", "Foo"},
         {"camlFoo__bar_0", "Foo.bar"},
         {"camlA__B__C__D__func_0", "A.B.C.D.func"},
@@ -110,20 +112,10 @@ TEST(OxCamlDemangle, FlatCorpus) {
         {"camlFoo__$2b$2b$2b_1", "Foo.+++"},
         {"camlStdlib__anon_fn$5bstdlib$2eml$3a334$2c0$2d$2d54$5d_1453",
          "Stdlib.anon_fn[stdlib.ml:334,0--54]"},           // span kept
+        {"camlFoo__$3e$3e$3d_12", "Foo.>>="},              // "$xx" escapes
+        {"camlIndexing__.$25$28$29_2_14_code", "Indexing..%()"},
         {"_camlFoo__bar_0", "Foo.bar"},                    // macOS "_caml" prefix
         {"_camlStdlib__array__map_154", "Stdlib.array.map"},
-        // flat1 Linux escapes
-        {"camlFoo__$3e$3e$3d_12", "Foo.>>="},
-        {"camlIndexing__.$25$28$29_2_14_code", "Indexing..%()"},
-        // flat1 macOS flavour: "$" separator, "$$xx"/"$$$xx" escapes
-        {"camlA$B$C$D$func_0", "A.B.C.D.func"},
-        {"camlFoo$$$3e$$3e$$3d_12", "Foo.>>="},
-        {"camlFoo$$$2b$$2b_5", "Foo.++"},
-        {"camlIndexing$$$2e$$25$$28$$29_2_14_code", "Indexing..%()"},
-        {"camlStdlib$anon_fn$$5bstdlib$$2eml$$3a334$$2c0$$2d$$2d54$$5d_1453",
-         "Stdlib.anon_fn[stdlib.ml:334,0--54]"},
-        {"camlList$add_42", "List.add"},
-        {"camlBuffer$add_string_5_28_code", "Buffer.add_string"},
         {"_camlStdlib__List__map_15_113_code", "Stdlib.List.map"},
     };
     for (const auto &C : Cases)

--- a/llvm/unittests/Demangle/OxCamlDemangleTest.cpp
+++ b/llvm/unittests/Demangle/OxCamlDemangleTest.cpp
@@ -92,10 +92,49 @@ TEST(OxCamlDemangle, StructuredCorpus) {
         CheckDemangle(C);
 }
 
+// Golden corpus for the legacy flat schemes from oxcaml/oxcaml PR #5100
+// (testsuite/tests/tool-ocamlfilt/flat0.{sh,reference} and flat1.{sh,reference}).
+// flat0 = OCaml <= 5.2 ("__" separators, "$xx" escapes); flat1 = OCaml >= 5.3,
+// which adds the macOS flavour ("$" separators, "$$xx"/"$$$xx" escapes,
+// auto-detected). The trailing compiler suffix is preserved.
+TEST(OxCamlDemangle, FlatCorpus) {
+    static const DemangleCase Cases[] = {
+        // flat0 (and Linux flat1, which is identical)
+        {"camlFoo", "Foo"},
+        {"camlFoo__bar_0", "Foo.bar_0"},
+        {"camlA__B__C__D__func_0", "A.B.C.D.func_0"},
+        {"camlFoo__bar_baz_42", "Foo.bar_baz_42"},
+        {"camlStdlib__array__map_154", "Stdlib.array.map_154"},
+        {"camlBaz__Foo__Bar__init_0", "Baz.Foo.Bar.init_0"},
+        {"camlFoo__", "Foo."},
+        {"camlStdlib__bytes__$2b$2b_2205", "Stdlib.bytes.++_2205"},
+        {"camlFoo__$2b$2b$2b_1", "Foo.+++_1"},
+        {"camlStdlib__anon_fn$5bstdlib$2eml$3a334$2c0$2d$2d54$5d_1453",
+         "Stdlib.anon_fn[stdlib.ml:334,0--54]_1453"},
+        {"_camlFoo__bar_0", "Foo.bar_0"},                  // macOS "_caml" prefix
+        {"_camlStdlib__array__map_154", "Stdlib.array.map_154"},
+        // flat1 Linux escapes
+        {"camlFoo__$3e$3e$3d_12", "Foo.>>=_12"},
+        {"camlIndexing__.$25$28$29_2_14_code", "Indexing..%()_2_14_code"},
+        // flat1 macOS flavour: "$" separator, "$$xx"/"$$$xx" escapes
+        {"camlA$B$C$D$func_0", "A.B.C.D.func_0"},
+        {"camlFoo$$$3e$$3e$$3d_12", "Foo.>>=_12"},
+        {"camlFoo$$$2b$$2b_5", "Foo.++_5"},
+        {"camlIndexing$$$2e$$25$$28$$29_2_14_code", "Indexing..%()_2_14_code"},
+        {"camlStdlib$anon_fn$$5bstdlib$$2eml$$3a334$$2c0$$2d$$2d54$$5d_1453",
+         "Stdlib.anon_fn[stdlib.ml:334,0--54]_1453"},
+        {"camlList$add_42", "List.add_42"},
+        {"camlBuffer$add_string_5_28_code", "Buffer.add_string_5_28_code"},
+        {"_camlStdlib__List__map_15_113_code", "Stdlib.List.map_15_113_code"},
+    };
+    for (const auto &C : Cases)
+        CheckDemangle(C);
+}
+
 // Inputs that must be rejected, from PR #5100 reject.{sh,reference} plus the
-// empty-path case. The macOS "__Caml" and lowercase flat "__caml" prefixes are
-// stripped/handled by surrounding lldb code, so the demangler proper only
-// accepts the "_Caml" prefix.
+// empty-path case. Flat prefixes are only accepted when followed by an
+// uppercase module letter, so the runtime symbol "caml_foo" and the
+// double-underscore "__camlFoo" are rejected.
 TEST(OxCamlDemangle, RejectCorpus) {
     static const DemangleCase Cases[] = {
         {"_Caml", nullptr},                       // valid prefix, empty path
@@ -113,4 +152,35 @@ TEST(OxCamlDemangle, RejectCorpus) {
     };
     for (const auto &C : Cases)
         CheckDemangle(C);
+}
+
+// oxcamlDemangleNoStamp: the display variant strips the trailing compiler
+// stamp ("_<digits>", "_<digits>_code", "_<digits>_<digits>_code") while
+// keeping source spans, operators, and identifier underscores intact.
+static void CheckNoStamp(const char *Mangled, const char *Expected) {
+    char *Demangled = llvm::oxcamlDemangleNoStamp(Mangled);
+    EXPECT_STREQ(Demangled, Expected) << "input: " << Mangled;
+    std::free(Demangled);
+}
+
+TEST(OxCamlDemangle, DisplayNoStamp) {
+    // structured
+    CheckNoStamp("_CamlU3FooM3BarF3baz", "Foo.Bar.baz");        // no stamp
+    CheckNoStamp("_CamlU3FooFu8A3e3e3d_", "Foo.>>=");           // operator, no stamp
+    CheckNoStamp("_CamlU4MainF11say_hello_0_5_code", "Main.say_hello");
+    CheckNoStamp("_CamlU4MainM4TestF5foo_1_6_code", "Main.Test.foo");
+    CheckNoStamp("_CamlU4MainSu15E2e_testml_5_15_300",
+                 "Main.mod(test.ml:5:15)"); // span kept, _300 stripped
+    CheckNoStamp("_CamlU4MainF4mainLu15E2e_mainml_7_32F4fn_4_9_code",
+                 "Main.main.fn(main.ml:7:32).fn");
+    // flat
+    CheckNoStamp("camlFoo__bar_0", "Foo.bar");
+    CheckNoStamp("camlA__B__C__D__func_0", "A.B.C.D.func");
+    CheckNoStamp("camlStdlib__array__map_154", "Stdlib.array.map");
+    CheckNoStamp("camlBuffer$add_string_5_28_code",
+                 "Buffer.add_string"); // internal '_' kept, stamp stripped
+    CheckNoStamp("camlStdlib__anon_fn$5bstdlib$2eml$3a334$2c0$2d$2d54$5d_1453",
+                 "Stdlib.anon_fn[stdlib.ml:334,0--54]"); // span kept
+    // not OxCaml -> nullptr passes through
+    CheckNoStamp("caml_foo", nullptr);
 }

--- a/llvm/utils/gn/secondary/llvm/lib/Demangle/BUILD.gn
+++ b/llvm/utils/gn/secondary/llvm/lib/Demangle/BUILD.gn
@@ -7,6 +7,7 @@ static_library("Demangle") {
     "ItaniumDemangle.cpp",
     "MicrosoftDemangle.cpp",
     "MicrosoftDemangleNodes.cpp",
+    "OxCamlDemangle.cpp",
     "RustDemangle.cpp",
   ]
 }


### PR DESCRIPTION
The demangler replicates the behaviour of the ocamlfilt demangler in oxcaml#5100 with a minor change to macOS symbol prefixes which lldb trims before they
  are passed to demangling. We retain the suffixes for symbols as they ensure uniqueness of symbols.

This is based off LLVM 21, the earlier PR https://github.com/ocaml-flambda/llvm-project/pull/27 was based on LLVM 16.

[Companion OxCaml PR](https://github.com/oxcaml/oxcaml/pull/6384)