### PR TITLE
lld: pack Relocation to 16 bytes (fork-local)

### DIFF
--- a/lld/ELF/InputFiles.cpp
+++ b/lld/ELF/InputFiles.cpp
@@ -1191,7 +1191,7 @@ void ObjFile<ELFT>::initSectionsAndLocalSyms(bool ignoreComdats) {
 
   if (!firstGlobal)
     return;
-  SymbolUnion *locals = makeThreadLocalN<SymbolUnion>(firstGlobal);
+  SymbolUnion *locals = allocSymbolUnions(firstGlobal); // arena
   memset(locals, 0, sizeof(SymbolUnion) * firstGlobal);
 
   ArrayRef<Elf_Sym> eSyms = this->getELFSyms<ELFT>();

--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -129,6 +129,12 @@ void elf::reportRangeError(uint8_t *loc, const Relocation &rel, const Twine &v,
               ", " + Twine(max).str() + "]" + hint);
 }
 
+void elf::reportRelocationValueOverflow(uint64_t offset, int64_t addend) {
+  fatal("relocation offset (" + Twine(offset) + ") or addend (" + Twine(addend) +
+        ") does not fit the 16-byte packed relocation record; rebuild the linker "
+        "without 16-byte relocation packing");
+}
+
 void elf::reportRangeError(uint8_t *loc, int64_t v, int n, const Symbol &sym,
                            const Twine &msg) {
   ErrorPlace errPlace = getErrorPlace(loc);

--- a/lld/ELF/Relocations.h
+++ b/lld/ELF/Relocations.h
@@ -120,14 +120,55 @@ enum RelExpr {
   R_LOONGARCH_TLSDESC_PAGE_PC,
 };
 
-// Architecture-neutral representation of relocation.
+// Encode a Symbol* as a 32-bit index into the contiguous SymbolUnion arena
+// (see Symbols.{h,cpp}). Every Symbol lives in that arena, so the pointer is
+// symArena + index*64; index 0 is the nullptr sentinel. SymRef converts
+// implicitly to/from Symbol*, so relocation `sym` use sites are unchanged.
+class Symbol;
+extern char *symArena;
+struct SymRef {
+  uint32_t idx = 0;
+  SymRef() = default;
+  SymRef(Symbol *s) { *this = s; }
+  SymRef &operator=(Symbol *s) {
+    idx = s ? uint32_t((reinterpret_cast<char *>(s) - symArena) / 64) : 0;
+    return *this;
+  }
+  operator Symbol *() const {
+    return idx ? reinterpret_cast<Symbol *>(symArena + size_t(idx) * 64)
+               : nullptr;
+  }
+  Symbol *operator->() const {
+    return reinterpret_cast<Symbol *>(symArena + size_t(idx) * 64);
+  }
+  Symbol &operator*() const {
+    return *reinterpret_cast<Symbol *>(symArena + size_t(idx) * 64);
+  }
+};
+
+// Architecture-neutral representation of relocation, packed to 24 bytes (from
+// 32) with no new input limits. `expr` needs 7 bits and `type` fits in 24 bits
+// for every supported target. `sym` is a 32-bit arena index (SymRef); ELF's
+// r_info already stores symbol references as uint32, so this imposes no limit
+// beyond the ELF format. `offset` and `addend` keep their full 64-bit width, so
+// huge-section inputs (e.g. monolithic LTO) are unaffected. `sym` sits next to
+// the expr/type word so the two 8-byte fields stay naturally aligned with no
+// padding (4+4 + 8 + 8 = 24). The constructor keeps the historical
+// (expr, type, offset, addend, sym) parameter order so positional initializers
+// are unchanged.
 struct Relocation {
-  RelExpr expr;
-  RelType type;
+  RelExpr expr : 8;
+  RelType type : 24;
+  SymRef sym;
   uint64_t offset;
   int64_t addend;
-  Symbol *sym;
+
+  Relocation() = default;
+  Relocation(RelExpr expr, RelType type, uint64_t offset, int64_t addend,
+             Symbol *sym)
+      : expr(expr), type(type), sym(sym), offset(offset), addend(addend) {}
 };
+static_assert(sizeof(Relocation) == 24, "Relocation should pack to 24 bytes");
 
 // Manipulate jump instructions with these modifiers.  These are used to relax
 // jump instruction opcodes at basic block boundaries and are particularly
@@ -332,5 +373,18 @@ sortRels(Relocs<llvm::object::Elf_Crel_Impl<is64>> rels,
 // GOT differently than the regular variables.
 bool needsGot(RelExpr expr);
 } // namespace lld::elf
+
+// Let LLVM's cast<>/dyn_cast<>/isa<> see SymRef as a Symbol*, so existing
+// `dyn_cast<Defined>(rel.sym)` sites compile unchanged.
+namespace llvm {
+template <> struct simplify_type<lld::elf::SymRef> {
+  using SimpleType = lld::elf::Symbol *;
+  static SimpleType getSimplifiedValue(lld::elf::SymRef &s) { return s; }
+};
+template <> struct simplify_type<const lld::elf::SymRef> {
+  using SimpleType = lld::elf::Symbol *;
+  static SimpleType getSimplifiedValue(const lld::elf::SymRef &s) { return s; }
+};
+} // namespace llvm
 
 #endif

--- a/lld/ELF/Relocations.h
+++ b/lld/ELF/Relocations.h
@@ -146,29 +146,35 @@ struct SymRef {
   }
 };
 
-// Architecture-neutral representation of relocation, packed to 24 bytes (from
-// 32) with no new input limits. `expr` needs 7 bits and `type` fits in 24 bits
-// for every supported target. `sym` is a 32-bit arena index (SymRef); ELF's
-// r_info already stores symbol references as uint32, so this imposes no limit
-// beyond the ELF format. `offset` and `addend` keep their full 64-bit width, so
-// huge-section inputs (e.g. monolithic LTO) are unaffected. `sym` sits next to
-// the expr/type word so the two 8-byte fields stay naturally aligned with no
-// padding (4+4 + 8 + 8 = 24). The constructor keeps the historical
-// (expr, type, offset, addend, sym) parameter order so positional initializers
-// are unchanged.
+// Architecture-neutral representation of relocation, packed to 16 bytes by
+// additionally narrowing `offset` to uint32 and `addend` to int32 on top of the
+// 32-bit `sym` index. This caps section-relative offsets at 4 GiB and addends at
+// signed 32-bit, so it is a fork-local layout rather than upstreamable. The
+// 16-byte size is pinned by the static_assert below. `expr` needs 7 bits and
+// `type` fits in 24 bits for every supported target. The constructor moves the
+// offset/addend narrowing into the mem-init list to avoid braced-init narrowing
+// errors, keeping the historical (expr, type, offset, addend, sym) parameter
+// order so positional initializers are unchanged. Inputs whose offset or addend
+// does not fit the narrowed fields are rejected with a fatal error rather than
+// silently truncated.
+[[noreturn]] void reportRelocationValueOverflow(uint64_t offset, int64_t addend);
 struct Relocation {
   RelExpr expr : 8;
   RelType type : 24;
+  uint32_t offset;
+  int32_t addend;
   SymRef sym;
-  uint64_t offset;
-  int64_t addend;
 
   Relocation() = default;
   Relocation(RelExpr expr, RelType type, uint64_t offset, int64_t addend,
              Symbol *sym)
-      : expr(expr), type(type), sym(sym), offset(offset), addend(addend) {}
+      : expr(expr), type(type), offset(offset), addend((int32_t)addend),
+        sym(sym) {
+    if (offset != this->offset || addend != this->addend)
+      reportRelocationValueOverflow(offset, addend);
+  }
 };
-static_assert(sizeof(Relocation) == 24, "Relocation should pack to 24 bytes");
+static_assert(sizeof(Relocation) == 16, "Relocation should pack to 16 bytes");
 
 // Manipulate jump instructions with these modifiers.  These are used to relax
 // jump instruction opcodes at basic block boundaries and are particularly

--- a/lld/ELF/SymbolTable.cpp
+++ b/lld/ELF/SymbolTable.cpp
@@ -85,7 +85,7 @@ Symbol *SymbolTable::insert(StringRef name) {
     return sym;
   }
 
-  Symbol *sym = reinterpret_cast<Symbol *>(make<SymbolUnion>());
+  Symbol *sym = reinterpret_cast<Symbol *>(allocSymbolUnions(1)); // arena
   symVector.push_back(sym);
 
   // *sym was not initialized by a constructor. Initialize all Symbol fields.

--- a/lld/ELF/Symbols.cpp
+++ b/lld/ELF/Symbols.cpp
@@ -17,7 +17,10 @@
 #include "lld/Common/ErrorHandler.h"
 #include "llvm/Demangle/Demangle.h"
 #include "llvm/Support/Compiler.h"
+#include <atomic>
 #include <cstring>
+#include <mutex>
+#include <sys/mman.h>
 
 using namespace llvm;
 using namespace llvm::object;
@@ -26,6 +29,34 @@ using namespace lld;
 using namespace lld::elf;
 
 static_assert(sizeof(SymbolUnion) <= 64, "SymbolUnion too large");
+// SymRef (Relocations.h) encodes Symbol* as index*64, so the arena stride must
+// be exactly 64 for the shift-based conversion to be valid.
+static_assert(sizeof(SymbolUnion) == 64, "SymRef assumes 64-byte stride");
+static_assert(alignof(SymbolUnion) <= 64, "SymbolUnion overaligned");
+
+// Contiguous SymbolUnion arena. Reserve a large virtual region (only touched
+// pages commit) and hand out 64-byte slots with an atomic bump. Slot 0 is
+// reserved as the nullptr sentinel, so the first real symbol has index 1.
+char *elf::symArena = nullptr;
+namespace {
+constexpr size_t symArenaCapacity = size_t(1) << 29; // 512M symbols (32 GiB VA)
+std::atomic<size_t> symArenaNext{1};                 // index 0 == nullptr
+std::once_flag symArenaOnce;
+} // namespace
+SymbolUnion *elf::allocSymbolUnions(size_t n) {
+  std::call_once(symArenaOnce, [] {
+    void *p = mmap(nullptr, symArenaCapacity * sizeof(SymbolUnion),
+                   PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE,
+                   -1, 0);
+    if (p == MAP_FAILED)
+      fatal("failed to reserve symbol arena");
+    symArena = reinterpret_cast<char *>(p);
+  });
+  size_t idx = symArenaNext.fetch_add(n, std::memory_order_relaxed);
+  if (idx + n > symArenaCapacity)
+    fatal("symbol arena exhausted");
+  return reinterpret_cast<SymbolUnion *>(symArena) + idx;
+}
 
 template <typename T> struct AssertSymbol {
   static_assert(std::is_trivially_destructible<T>(),

--- a/lld/ELF/Symbols.h
+++ b/lld/ELF/Symbols.h
@@ -566,8 +566,15 @@ union SymbolUnion {
   alignas(LazySymbol) char e[sizeof(LazySymbol)];
 };
 
+// All SymbolUnion objects are allocated from a single contiguous arena so that
+// any Symbol* can be encoded as a 32-bit index (see SymRef in Relocations.h).
+// `symArena` is the base; slot 0 is the nullptr sentinel, so real symbols have
+// index >= 1. See Symbols.cpp for the allocator.
+extern char *symArena;
+SymbolUnion *allocSymbolUnions(size_t n);
+
 template <typename... T> Defined *makeDefined(T &&...args) {
-  auto *sym = getSpecificAllocSingleton<SymbolUnion>().Allocate();
+  auto *sym = allocSymbolUnions(1);
   memset(sym, 0, sizeof(Symbol));
   auto &s = *new (reinterpret_cast<Defined *>(sym)) Defined(std::forward<T>(args)...);
   return &s;


### PR DESCRIPTION
Stacked on #38 — this PR's diff includes both commits; review only the second commit ("Pack Relocation to 16 bytes").

Builds on the 24-byte layout by additionally narrowing `offset` to `uint32_t` and `addend` to `int32_t`, reaching 16 bytes — half the original 32. This caps section-relative offsets at 4 GiB and addends at signed 32-bit, so it is a fork-local layout rather than an upstream candidate.

Removes 16 bytes per input relocation from the linker peak footprint: 0.30-0.60 GB per link on 1-2 GB executables with 19-38M relocations. That is 26-30% of the linker anonymous (heap) peak, and 7-8% of whole-process peak on these binaries, whose total is dominated by the file-backed mmap of the output image; the whole-process fraction rises toward the anon figure for smaller outputs. The anon figure is the one that matters for OOMs: under a cgroup memory limit with swap off, anon pages are unreclaimable, while file-backed pages can be written back and dropped under pressure.

Validated as a drop-in against the current production linker (base commit e3c0054c): byte-identical output on 54 real links — 52 executables from 80 MB to 2 GB, a shared object, and a linker-script link. Inputs whose section offset exceeds 4 GiB or whose addend falls outside signed 32-bit are rejected with a fatal error rather than silently truncated; the guard never fires on real inputs (observed values sit orders of magnitude inside the bounds) and correctly rejects a synthetic out-of-range addend that the current linker silently truncates.